### PR TITLE
Fix permission checking for performance counters

### DIFF
--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -76,9 +76,9 @@ function check_Counteren(csr : csreg, p : Privilege) -> bool =
     (0xC01, Supervisor) => mcounteren.TM() == true,
     (0xC02, Supervisor) => mcounteren.IR() == true,
 
-    (0xC00, User) => scounteren.CY() == true,
-    (0xC01, User) => scounteren.TM() == true,
-    (0xC02, User) => scounteren.IR() == true,
+    (0xC00, User) => mcounteren.CY() == true & scounteren.CY() == true,
+    (0xC01, User) => mcounteren.TM() == true & scounteren.TM() == true,
+    (0xC02, User) => mcounteren.IR() == true & scounteren.IR() == true,
 
     (_, _) => /* no HPM counters for now */
               if   0xC03 <=_u csr & csr <=_u 0xC1F

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -53,6 +53,11 @@ function is_CSR_defined (csr : bits(12), p : Privilege) -> bool =
     /* disabled trigger/debug module */
     0x7a0 => p == Machine,
 
+    /* counters */
+    0xC00 => true,
+    0xC01 => false, // mtime is memory-mapped
+    0xC02 => true,
+
     /* check extensions */
     _     => is_UExt_CSR_defined(csr, p)   // 'N' extension
   }


### PR DESCRIPTION
This pull request consists of two patches.

The first patch fixes accesses to `cycle`/`instret`, which should be allowed (e.g., `rdcycle` in M-mode); the current code unconditionally throws an exception.  The cause is that `check_Counteren()` is short-circuited by `is_CSR_defined()`.  Note that the patch keeps `time` hidden as before, since it's accessible as a memory-mapped register.

The second patch fixes checks for U-mode accesses to counters.  According to the specification 3.1.12, "When the CY, TM, IR, or HPMn bit in the `mcounteren` register is clear, attempts to read the `cycle`, `time`, `instret`, or `hpmcountern` register while executing in S-mode or U-mode will cause an illegal instruction exception."  In other words, U-mode accesses to these counters require checks on both `mcounteren` and `scounteren`.  The current code checks `scounteren` only and ignores `mcounteren`.