### PR TITLE
Two small README updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ Coq, Isabelle and HOL4.
 Building the model
 ------------------
 
-Install Sail via Opam, or build Sail from source and have `SAIL_DIR` in
-your environment pointing to its top-level directory.
+Install Sail [via
+Opam](https://github.com/rems-project/sail/wiki/OPAMInstall), or build Sail
+from source and have `SAIL_DIR` in your environment pointing to its
+top-level directory.
 
 ```
 $ make
@@ -103,7 +105,16 @@ corresponding prover libraries in the Sail directory
 Executing test binaries
 -----------------------
 
-The C and OCaml simulators can be used to execute small test binaries.
+The C and OCaml simulators can be used to execute small test binaries.  The
+OCaml simulator depends on the Device Tree Compiler package, which can be
+installed in Ubuntu with:
+
+```
+$ sudo apt-get install device-tree-compiler
+```
+
+Then, you can run test binaries:
+
 
 ```
 $ ./ocaml_emulator/riscv_ocaml_sim_<arch>  <elf-file>


### PR DESCRIPTION
Two suggested edits to the README based on my attempt to build the project.  One is a link explaining how to install sail via opam at the appropriate place, and the other documents a dependency on `dtc` that seems required to use the ocaml simulator.