### PR TITLE
Display correct filename in message when using -T

### DIFF
--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -224,7 +224,7 @@ char *process_args(int argc, char **argv)
       break;
     case 'T':
       sig_file = strdup(optarg);
-      fprintf(stderr, "using %s for test-signature output.\n", term_log);
+      fprintf(stderr, "using %s for test-signature output.\n", sig_file);
       break;
     case 'h':
       print_usage(argv[0], 0);


### PR DESCRIPTION
This untested but trivial change fixes a clear bug in the filename displayed when using -T.