### PR TITLE
Correction to flag descriptions

### DIFF
--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -186,11 +186,11 @@ char *process_args(int argc, char **argv)
       rv_enable_misaligned = true;
       break;
     case 'C':
-      fprintf(stderr, "enabling RVC compressed instructions.\n");
+      fprintf(stderr, "disabling RVC compressed instructions.\n");
       rv_enable_rvc = false;
       break;
     case 'I':
-      fprintf(stderr, "enabling writable misa CSR.\n");
+      fprintf(stderr, "disabling writable misa CSR.\n");
       rv_enable_writable_misa = false;
       break;
     case 'i':


### PR DESCRIPTION
These two command-line flags printed the reverse of what they were actually doing.