### PR TITLE
Zero extend rather than sign extend rvfi-dii reports (usefull for 32 …

### DIFF
--- a/model/riscv_fetch_rvfi.sail
+++ b/model/riscv_fetch_rvfi.sail
@@ -5,12 +5,12 @@ function fetch() -> FetchResult =
   else {
     let i = rvfi_instruction.rvfi_insn();
     rvfi_exec->rvfi_order()    = minstret;
-    rvfi_exec->rvfi_pc_rdata() = EXTS(PC);
-    rvfi_exec->rvfi_insn()     = EXTS(i);
+    rvfi_exec->rvfi_pc_rdata() = EXTZ(PC);
+    rvfi_exec->rvfi_insn()     = EXTZ(i);
 
     /* TODO: should we write these even if they're not really registers? */
-    rvfi_exec->rvfi_rs1_data() = EXTS(X(i[19 .. 15]));
-    rvfi_exec->rvfi_rs2_data() = EXTS(X(i[24 .. 20]));
+    rvfi_exec->rvfi_rs1_data() = EXTZ(X(i[19 .. 15]));
+    rvfi_exec->rvfi_rs2_data() = EXTZ(X(i[24 .. 20]));
     rvfi_exec->rvfi_rs1_addr() = sail_zero_extend(i[19 .. 15],8);
     rvfi_exec->rvfi_rs2_addr() = sail_zero_extend(i[24 .. 20],8);
 

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -42,7 +42,7 @@ function checked_mem_read forall 'n, 'n > 0. (t : ReadType, addr : xlenbits, wid
 $ifdef RVFI_DII
 val rvfi_read : forall 'n, 'n > 0. (xlenbits, atom('n), MemoryOpResult(bits(8 * 'n))) -> unit effect {wreg}
 function rvfi_read (addr, width, result) = {
-  rvfi_exec->rvfi_mem_addr() = EXTS(addr);
+  rvfi_exec->rvfi_mem_addr() = EXTZ(addr);
   match result {
     MemValue(v) => if   width <= 8
                    then { rvfi_exec->rvfi_mem_rdata() = sail_zero_extend(v,64);
@@ -96,7 +96,7 @@ function mem_write_ea (addr, width, aq, rl, con) = {
 $ifdef RVFI_DII
 val rvfi_write : forall 'n, 'n > 0. (xlenbits, atom('n), bits(8 * 'n)) -> unit effect {wreg}
 function rvfi_write (addr, width, value) = {
-  rvfi_exec->rvfi_mem_addr() = EXTS(addr);
+  rvfi_exec->rvfi_mem_addr() = EXTZ(addr);
   if width <= 8 then {
     rvfi_exec->rvfi_mem_wdata() = sail_zero_extend(value,64);
     rvfi_exec->rvfi_mem_wmask() = rvfi_encode_width_mask(width);

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -86,7 +86,7 @@ function rX r = {
 $ifdef RVFI_DII
 val rvfi_wX : forall 'n, 0 <= 'n < 32. (regno('n), xlenbits) -> unit effect {wreg}
 function rvfi_wX (r,v) = {
-  rvfi_exec->rvfi_rd_wdata() = EXTS(v);
+  rvfi_exec->rvfi_rd_wdata() = EXTZ(v);
   rvfi_exec->rvfi_rd_addr() = to_bits(8,r);
 }
 $else

--- a/model/riscv_step_rvfi.sail
+++ b/model/riscv_step_rvfi.sail
@@ -6,7 +6,7 @@ function ext_pre_step_hook()  -> unit = ()
 
 function ext_post_step_hook() -> unit = {
   /* record the next pc */
-  rvfi_exec->rvfi_pc_wdata() = EXTS(PC)
+  rvfi_exec->rvfi_pc_wdata() = EXTZ(PC)
 }
 
 val ext_init : unit -> unit effect {wreg}


### PR DESCRIPTION
…rvfi-dii comparisons where upper bits are not expected to have information in them)