### PR TITLE
Expand getopt_long option string to multiple lines

### DIFF
--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -196,7 +196,25 @@ char *process_args(int argc, char **argv)
   int c, idx = 1;
   uint64_t ram_size = 0;
   while(true) {
-    c = getopt_long(argc, argv, "admCIispz:b:t:hr:T:V::v::l:", options, &idx);
+    c = getopt_long(argc, argv,
+                    "a"
+                    "d"
+                    "m"
+                    "C"
+                    "I"
+                    "i"
+                    "s"
+                    "p"
+                    "z:"
+                    "b:"
+                    "t:"
+                    "h"
+                    "r:"
+                    "T:"
+                    "V::"
+                    "v::"
+                    "l:"
+                         , options, &idx);
     if (c == -1) break;
     switch (c) {
     case 'a':


### PR DESCRIPTION
I've made some local changes to the command-line options in `riscv_sim.c`, and every time I merge/rebase upstream changes it's a mess because the options are all in one line. This change splits that long string up into one line per option.

This will make future changes easier to read and merge, since adding and removing options will show up as entire lines that change instead of a few characters in the middle of the line.