### PR TITLE
Run Sail with -dno_cast even when it comes from opam package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,12 @@ SAIL_COQ_SRCS  = $(addprefix model/,$(SAIL_ARCH_SRCS) $(SAIL_SEQ_INST_SRCS) $(SA
 
 PLATFORM_OCAML_SRCS = $(addprefix ocaml_emulator/,platform.ml platform_impl.ml riscv_ocaml_sim.ml)
 
+SAIL_FLAGS += -dno_cast
+
 # Attempt to work with either sail from opam or built from repo in SAIL_DIR
 ifneq ($(SAIL_DIR),)
 # Use sail repo in SAIL_DIR
-SAIL:=$(SAIL_DIR)/sail -dno_cast
+SAIL:=$(SAIL_DIR)/sail
 export SAIL_DIR
 else
 # Use sail from opam package


### PR DESCRIPTION
Change a381a83 added `-dno_cast` to the Sail command line. But there are two places where `SAIL` is defined in the Makefile (depending on whether we're running from opam or built from repo in `SAIL_DIR`), and that change only affected one of the two.

Shouldn't that flag apply to both?

This change uses `SAIL_FLAGS` to apply `-dno_cast` to the Sail command line no matter where it's run from.

(There is the possibility that the version of Sail in opam is too old to support the `-dno_cast` flag, so a381a83 deliberately did not apply the flag to that version. If so, that should be explained somewhere, at least in the commit message.)

(Additional nit: I'm unable to fully comprehend the commit message in a381a83, partly because it's not written in [imperative mood](https://chris.beams.io/posts/git-commit/). "RISC-V spec" is a noun and doesn't describe a change of any kind.)