### PR TITLE
CSR extension point

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,12 @@ generated_definitions/c/riscv_model_$(ARCH).c: $(SAIL_SRCS) model/main.sail Make
 	mkdir -p generated_definitions/c
 	$(SAIL) $(SAIL_FLAGS) -O -Oconstant_fold -memo_z3 -c -c_include riscv_prelude.h -c_include riscv_platform.h -c_no_main $(SAIL_SRCS) model/main.sail -o $(basename $@)
 
+# convenience target
+.PHONY: csim
+csim: c_emulator/riscv_sim_$(ARCH)
+.PHONY: rvfi
+rvfi: c_emulator/riscv_rvfi
+
 c_emulator/riscv_sim_$(ARCH): generated_definitions/c/riscv_model_$(ARCH).c $(C_INCS) $(C_SRCS) Makefile
 	gcc -g $(C_WARNINGS) $(C_FLAGS) $< $(C_SRCS) $(SAIL_LIB_DIR)/*.c $(C_LIBS) -o $@
 

--- a/model/riscv_ext_regs.sail
+++ b/model/riscv_ext_regs.sail
@@ -12,3 +12,18 @@ to omnipotent instead of null).
  */
 val ext_rvfi_init : unit -> unit effect {wreg}
 function ext_rvfi_init () = ()
+
+
+/*!
+THIS(csrno, priv, isWrite) allows an extension to block access to csrno,
+at Privilege level priv. It should return true if the access is allowed.
+*/
+val ext_check_CSR : (bits(12), Privilege, bool) -> bool
+function ext_check_CSR (csrno, p, isWrite) = true
+
+/*!
+THIS is called if ext_check_CSR returns false. It should
+cause an appropriate RISCV exception.
+ */
+val ext_check_CSR_fail : unit->unit
+function ext_check_CSR_fail () = ()

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -714,9 +714,11 @@ mapping clause encdec = MRET()
   <-> 0b0011000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute MRET() = {
-  if   cur_privilege == Machine
-  then set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC))
-  else handle_illegal();
+  if   cur_privilege != Machine
+  then handle_illegal()
+  else if ~(ext_check_xret_priv (Machine))
+  then ext_fail_xret_priv ()
+  else set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC));
   RETIRE_FAIL
 }
 
@@ -729,15 +731,16 @@ mapping clause encdec = SRET()
   <-> 0b0001000 @ 0b00010 @ 0b00000 @ 0b000 @ 0b00000 @ 0b1110011
 
 function clause execute SRET() = {
-  match cur_privilege {
-    User       => handle_illegal(),
-    Supervisor => if   (~ (haveSupMode ())) | mstatus.TSR() == 0b1
-                  then handle_illegal()
-                  else set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC)),
-    Machine    => if   (~ (haveSupMode ()))
-                  then handle_illegal()
-                  else set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC))
+  let sret_illegal : bool = match cur_privilege {
+    User       => true,
+    Supervisor => ~ (haveSupMode ()) | mstatus.TSR() == 0b1,
+    Machine    => ~ (haveSupMode ())
   };
+  if   sret_illegal
+  then handle_illegal()
+  else if ~(ext_check_xret_priv (Supervisor))
+  then ext_fail_xret_priv ()
+  else set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC));
   RETIRE_FAIL
 }
 

--- a/model/riscv_insts_next.sail
+++ b/model/riscv_insts_next.sail
@@ -9,6 +9,8 @@ mapping clause encdec = URET()
 function clause execute URET() = {
   if   (~ (haveUsrMode()))
   then handle_illegal()
+  else if ~ (ext_check_xret_priv (User))
+  then ext_fail_xret_priv ()
   else set_next_pc(exception_handler(cur_privilege, CTL_URET(), PC));
   RETIRE_FAIL
 }

--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -179,6 +179,8 @@ function clause execute CSR(csr, rs1, rd, is_imm, op) = {
   };
   if ~ (check_CSR(csr, cur_privilege, isWrite))
   then { handle_illegal(); RETIRE_FAIL }
+  else if ~ (ext_check_CSR(csr, cur_privilege, isWrite))
+  then { ext_check_CSR_fail(); RETIRE_FAIL }
   else {
     let csr_val = readCSR(csr); /* could have side-effects, so technically shouldn't perform for CSRW[I] with rd == 0 */
     if isWrite then {

--- a/model/riscv_sys_exceptions.sail
+++ b/model/riscv_sys_exceptions.sail
@@ -2,6 +2,11 @@
 
 type ext_exception = unit
 
+/* Is XRET from given mode permitted by extension? */
+function ext_check_xret_priv (p : Privilege) : Privilege -> bool = true
+/* Called if above check fails */
+function ext_fail_xret_priv () : unit -> unit = ()
+
 function handle_trap_extension(p : Privilege, pc : xlenbits, u : option(unit)) -> unit = ()
 
 /* used for traps and ECALL */


### PR DESCRIPTION
This adds an extension point to allow extensions to veto CSR access similar to #23 (in fact I based this on that branch so those changes are also included here).