### PR TITLE
Fix parsing long options in the C emulator for RVFI-DII

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,17 +205,17 @@ generated_definitions/c/riscv_model_$(ARCH).c: $(SAIL_SRCS) model/main.sail Make
 .PHONY: csim
 csim: c_emulator/riscv_sim_$(ARCH)
 .PHONY: rvfi
-rvfi: c_emulator/riscv_rvfi
+rvfi: c_emulator/riscv_rvfi_$(ARCH)
 
 c_emulator/riscv_sim_$(ARCH): generated_definitions/c/riscv_model_$(ARCH).c $(C_INCS) $(C_SRCS) Makefile
 	gcc -g $(C_WARNINGS) $(C_FLAGS) $< $(C_SRCS) $(SAIL_LIB_DIR)/*.c $(C_LIBS) -o $@
 
-generated_definitions/c/riscv_rvfi_model.c: $(SAIL_RVFI_SRCS) model/main.sail Makefile
+generated_definitions/c/riscv_rvfi_model_$(ARCH).c: $(SAIL_RVFI_SRCS) model/main.sail Makefile
 	mkdir -p generated_definitions/c
 	$(SAIL) $(SAIL_FLAGS) -O -memo_z3 -c -c_include riscv_prelude.h -c_include riscv_platform.h -c_no_main $(SAIL_RVFI_SRCS) model/main.sail -o $(basename $@)
 	sed -i -e '/^[[:space:]]*$$/d' $@
 
-c_emulator/riscv_rvfi: generated_definitions/c/riscv_rvfi_model.c $(C_INCS) $(C_SRCS) Makefile
+c_emulator/riscv_rvfi_$(ARCH): generated_definitions/c/riscv_rvfi_model_$(ARCH).c $(C_INCS) $(C_SRCS) Makefile
 	gcc -g $(C_WARNINGS) $(C_FLAGS) $< -DRVFI_DII $(C_SRCS) $(SAIL_LIB_DIR)/*.c $(C_LIBS) -o $@
 
 latex: $(SAIL_SRCS) Makefile
@@ -365,7 +365,7 @@ clean:
 	-rm -rf generated_definitions/ocaml/* generated_definitions/c/* generated_definitions/latex/*
 	-rm -rf generated_definitions/lem/* generated_definitions/isabelle/* generated_definitions/hol4/* generated_definitions/coq/*
 	-rm -rf generated_definitions/for-rmem/*
-	-rm -f c_emulator/riscv_sim_RV32 c_emulator/riscv_sim_RV64  c_emulator/riscv_rvfi
+	-rm -f c_emulator/riscv_sim_RV32 c_emulator/riscv_sim_RV64  c_emulator/riscv_rvfi_RV32 c_emulator/riscv_rvfi_RV64
 	-rm -rf ocaml_emulator/_sbuild ocaml_emulator/_build ocaml_emulator/riscv_ocaml_sim_RV32 ocaml_emulator/riscv_ocaml_sim_RV64 ocaml_emulator/tracecmp
 	-rm -f *.gcno *.gcda
 	-rm -f z3_problems

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -193,7 +193,7 @@ static void read_dtb(const char *path)
 
 char *process_args(int argc, char **argv)
 {
-  int c, idx = 1;
+  int c;
   uint64_t ram_size = 0;
   while(true) {
     c = getopt_long(argc, argv,
@@ -214,7 +214,7 @@ char *process_args(int argc, char **argv)
                     "V::"
                     "v::"
                     "l:"
-                         , options, &idx);
+                         , options, NULL);
     if (c == -1) break;
     switch (c) {
     case 'a':
@@ -299,7 +299,7 @@ char *process_args(int argc, char **argv)
   }
   if (do_dump_dts) dump_dts();
 #ifdef RVFI_DII
-  if (idx > argc || (idx == argc && !rvfi_dii)) print_usage(argv[0], 0);
+  if (optind > argc || (optind == argc && !rvfi_dii)) print_usage(argv[0], 0);
 #else
   if (optind >= argc) {
     fprintf(stderr, "No elf file provided.\n");


### PR DESCRIPTION
idx, passed as longindex to getopt_long, is updated every time a long option is parsed to be the index of that option in the options array, not argv. We should instead use optind as in the non-RVFI-DII case, and we can remove the variable to avoid confusion since it is unused.

I have also included a convenience change so building RVFI behaves like non-RVFI, producing an executable suffixed with the architecture and isolating its intermediate build products.