### PR TITLE
Only listen for RVFI-DII messages on 127.0.0.1

### DIFF
--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -852,7 +852,7 @@ int main(int argc, char **argv)
     }
     struct sockaddr_in addr = {
       .sin_family = AF_INET,
-      .sin_addr.s_addr = INADDR_ANY,
+      .sin_addr.s_addr = htonl(INADDR_LOOPBACK),
       .sin_port = htons(rvfi_dii_port)
     };
     if (bind(listen_sock, (struct sockaddr *)&addr, sizeof(addr)) == -1) {


### PR DESCRIPTION
This fixes a firewall popup showing up on every start when using macOS.