### PR TITLE
Fix several pmpcfg issues

### DIFF
--- a/model/riscv_insts_zicsr.sail
+++ b/model/riscv_insts_zicsr.sail
@@ -117,10 +117,10 @@ function writeCSR (csr : csreg, value : xlenbits) -> unit = {
     (0x344,  _) => { mip = legalize_mip(mip, value); Some(mip.bits()) },
 
     // Note: Some(value) returned below is not the legalized value due to locked entries
-    (0x3A0,  _) => { pmpWriteCfgReg(0, value); Some(value) },  // pmpcfg0
-    (0x3A1, 32) => { pmpWriteCfgReg(1, value); Some(value) },  // pmpcfg1
-    (0x3A2,  _) => { pmpWriteCfgReg(2, value); Some(value) },  // pmpcfg2
-    (0x3A3, 32) => { pmpWriteCfgReg(3, value); Some(value) },  // pmpcfg3
+    (0x3A0,  _) => { pmpWriteCfgReg(0, value); Some(pmpReadCfgReg(0)) },  // pmpcfg0
+    (0x3A1, 32) => { pmpWriteCfgReg(1, value); Some(pmpReadCfgReg(1)) },  // pmpcfg1
+    (0x3A2,  _) => { pmpWriteCfgReg(2, value); Some(pmpReadCfgReg(2)) },  // pmpcfg2
+    (0x3A3, 32) => { pmpWriteCfgReg(3, value); Some(pmpReadCfgReg(3)) },  // pmpcfg3
 
     (0x3B0,  _) => { pmpaddr0  = pmpWriteAddr(pmpLocked(pmp0cfg),  pmpTORLocked(pmp1cfg),  pmpaddr0,  value); Some(pmpaddr0) },
     (0x3B1,  _) => { pmpaddr1  = pmpWriteAddr(pmpLocked(pmp1cfg),  pmpTORLocked(pmp2cfg),  pmpaddr1,  value); Some(pmpaddr1) },

--- a/model/riscv_pmp_regs.sail
+++ b/model/riscv_pmp_regs.sail
@@ -93,7 +93,7 @@ function pmpTORLocked(cfg: Pmpcfg_ent) -> bool =
    (cfg.L() == 0b1) & (pmpAddrMatchType_of_bits(cfg.A()) == TOR)
 
 function pmpWriteCfg(cfg: Pmpcfg_ent, v: bits(8)) -> Pmpcfg_ent =
-  if pmpLocked(cfg) then cfg else Mk_Pmpcfg_ent(v)
+  if pmpLocked(cfg) then cfg else Mk_Pmpcfg_ent(v & 0x9f)
 
 val pmpWriteCfgReg : forall 'n, 0 <= 'n < 4 . (atom('n), xlenbits) -> unit effect {rreg, wreg}
 function pmpWriteCfgReg(n, v) = {

--- a/model/riscv_pmp_regs.sail
+++ b/model/riscv_pmp_regs.sail
@@ -109,8 +109,8 @@ function pmpWriteCfgReg(n, v) = {
                 pmp6cfg  = pmpWriteCfg(pmp6cfg,  v[23..16]);
                 pmp7cfg  = pmpWriteCfg(pmp7cfg,  v[31..24]);
               },
-         2 => { pmp8cfg8 = pmpWriteCfg(pmp8cfg,  v[7 ..0]);
-                pmp9cfg9 = pmpWriteCfg(pmp9cfg,  v[15..8]);
+         2 => { pmp8cfg  = pmpWriteCfg(pmp8cfg,  v[7 ..0]);
+                pmp9cfg  = pmpWriteCfg(pmp9cfg,  v[15..8]);
                 pmp10cfg = pmpWriteCfg(pmp10cfg, v[23..16]);
                 pmp11cfg = pmpWriteCfg(pmp11cfg, v[31..24]);
               },
@@ -131,8 +131,8 @@ function pmpWriteCfgReg(n, v) = {
                 pmp6cfg  = pmpWriteCfg(pmp6cfg,  v[55..48]);
                 pmp7cfg  = pmpWriteCfg(pmp7cfg,  v[63..56])
               },
-         2 => { pmp8cfg8 = pmpWriteCfg(pmp8cfg,  v[7 ..0]);
-                pmp9cfg9 = pmpWriteCfg(pmp9cfg,  v[15..8]);
+         2 => { pmp8cfg  = pmpWriteCfg(pmp8cfg,  v[7 ..0]);
+                pmp9cfg  = pmpWriteCfg(pmp9cfg,  v[15..8]);
                 pmp10cfg = pmpWriteCfg(pmp10cfg, v[23..16]);
                 pmp11cfg = pmpWriteCfg(pmp11cfg, v[31..24]);
                 pmp12cfg = pmpWriteCfg(pmp12cfg, v[39..32]);


### PR DESCRIPTION
* pmp8cfg and pmp9cfg were not writable due to a typo in the source.

* Bits 5 and 6 of each 8-bit field must be masked to 0. (Is there a better way to do this using bitfield? I couldn't figure that out.)
