### PR TITLE
Fix mtval when store gets bad PMP

### DIFF
--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -299,10 +299,10 @@ function extend_value(is_unsigned, value) = match (value) {
 }
 
 val process_load : forall 'n, 0 < 'n <= xlen_bytes. (regidx, xlenbits, MemoryOpResult(bits(8 * 'n)), bool) -> Retired effect {escape, rreg, wreg}
-function process_load(rd, addr, value, is_unsigned) =
+function process_load(rd, vaddr, value, is_unsigned) =
   match extend_value(is_unsigned, value) {
     MemValue(result) => { X(rd) = result; RETIRE_SUCCESS },
-    MemException(e)  => { handle_mem_exception(addr, e); RETIRE_FAIL }
+    MemException(e)  => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
   }
 
 function check_misaligned(vaddr : xlenbits, width : word_width) -> bool =

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -325,16 +325,16 @@ function clause execute(LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)) = {
       then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
       else match translateAddr(vaddr, Read(Data)) {
         TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
-        TR_Address(addr, _) =>
+        TR_Address(paddr, _) =>
           match (width, sizeof(xlen)) {
             (BYTE, _)   =>
-               process_load(rd, vaddr, mem_read(Read(Data), addr, 1, aq, rl, false), is_unsigned),
+               process_load(rd, vaddr, mem_read(Read(Data), paddr, 1, aq, rl, false), is_unsigned),
             (HALF, _)   =>
-               process_load(rd, vaddr, mem_read(Read(Data), addr, 2, aq, rl, false), is_unsigned),
+               process_load(rd, vaddr, mem_read(Read(Data), paddr, 2, aq, rl, false), is_unsigned),
             (WORD, _)   =>
-               process_load(rd, vaddr, mem_read(Read(Data), addr, 4, aq, rl, false), is_unsigned),
+               process_load(rd, vaddr, mem_read(Read(Data), paddr, 4, aq, rl, false), is_unsigned),
             (DOUBLE, 64) =>
-               process_load(rd, vaddr, mem_read(Read(Data), addr, 8, aq, rl, false), is_unsigned)
+               process_load(rd, vaddr, mem_read(Read(Data), paddr, 8, aq, rl, false), is_unsigned)
           }
       }
   }
@@ -380,27 +380,27 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
       then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
       else match translateAddr(vaddr, Write(Data)) {
         TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
-        TR_Address(addr, _) => {
+        TR_Address(paddr, _) => {
           let eares : MemoryOpResult(unit) = match width {
-            BYTE   => mem_write_ea(addr, 1, aq, rl, false),
-            HALF   => mem_write_ea(addr, 2, aq, rl, false),
-            WORD   => mem_write_ea(addr, 4, aq, rl, false),
-            DOUBLE => mem_write_ea(addr, 8, aq, rl, false)
+            BYTE   => mem_write_ea(paddr, 1, aq, rl, false),
+            HALF   => mem_write_ea(paddr, 2, aq, rl, false),
+            WORD   => mem_write_ea(paddr, 4, aq, rl, false),
+            DOUBLE => mem_write_ea(paddr, 8, aq, rl, false)
           };
           match (eares) {
-            MemException(e) => { handle_mem_exception(addr, e); RETIRE_FAIL },
+            MemException(e) => { handle_mem_exception(paddr, e); RETIRE_FAIL },
             MemValue(_) => {
               let rs2_val = X(rs2);
               let res : MemoryOpResult(bool) = match (width, sizeof(xlen)) {
-                (BYTE, _)    => mem_write_value(addr, 1, rs2_val[7..0],  aq, rl, false),
-                (HALF, _)    => mem_write_value(addr, 2, rs2_val[15..0], aq, rl, false),
-                (WORD, _)    => mem_write_value(addr, 4, rs2_val[31..0], aq, rl, false),
-                (DOUBLE, 64) => mem_write_value(addr, 8, rs2_val,        aq, rl, false)
+                (BYTE, _)    => mem_write_value(paddr, 1, rs2_val[7..0],  aq, rl, false),
+                (HALF, _)    => mem_write_value(paddr, 2, rs2_val[15..0], aq, rl, false),
+                (WORD, _)    => mem_write_value(paddr, 4, rs2_val[31..0], aq, rl, false),
+                (DOUBLE, 64) => mem_write_value(paddr, 8, rs2_val,        aq, rl, false)
               };
               match (res) {
                 MemValue(true)  => RETIRE_SUCCESS,
                 MemValue(false) => internal_error("store got false from mem_write_value"),
-                MemException(e) => { handle_mem_exception(addr, e); RETIRE_FAIL }
+                MemException(e) => { handle_mem_exception(paddr, e); RETIRE_FAIL }
               }
             }
           }

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -388,7 +388,7 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
             DOUBLE => mem_write_ea(paddr, 8, aq, rl, false)
           };
           match (eares) {
-            MemException(e) => { handle_mem_exception(paddr, e); RETIRE_FAIL },
+            MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
             MemValue(_) => {
               let rs2_val = X(rs2);
               let res : MemoryOpResult(bool) = match (width, sizeof(xlen)) {
@@ -400,7 +400,7 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
               match (res) {
                 MemValue(true)  => RETIRE_SUCCESS,
                 MemValue(false) => internal_error("store got false from mem_write_value"),
-                MemException(e) => { handle_mem_exception(paddr, e); RETIRE_FAIL }
+                MemException(e) => { handle_mem_exception(vaddr, e); RETIRE_FAIL }
               }
             }
           }


### PR DESCRIPTION
I observed that when a store instruction has invalid PMP permissions and takes an access fault, the `mtval` register was being written with the physical address. It should always be a virtual address.

I renamed some identifiers in the code in the first few commits to make the problem more obvious, then fixed it in the final commit.
