### PR TITLE
Cleave ext_access_type in twain for R/W

### DIFF
--- a/model/riscv_addr_checks.sail
+++ b/model/riscv_addr_checks.sail
@@ -46,7 +46,9 @@ type ext_data_addr_error = unit
 
 /* Default data addr is just base register + immediate offset (may be zero).
    Extensions might override and add additional checks. */
-function ext_data_get_addr(base : regidx, offset : xlenbits, acc : AccessType(ext_access_type), width : word_width)
+function ext_data_get_addr(base : regidx, offset : xlenbits,
+                           acc : AccessType(ext_access_type_r, ext_access_type_w),
+                           width : word_width)
          -> Ext_DataAddr_Check(ext_data_addr_error) =
   let addr = X(base) + offset in
   Ext_DataAddr_OK(addr)

--- a/model/riscv_insts_aext.sail
+++ b/model/riscv_insts_aext.sail
@@ -44,7 +44,7 @@ function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
     /* Get the address, X(rs1) (no offset).
      * Extensions might perform additional checks on address validity.
      */
-    match ext_data_get_addr(rs1, zeros(), Read(Data), width) {
+    match ext_data_get_addr(rs1, zeros(), Read(RData), width) {
       Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
       Ext_DataAddr_OK(vaddr) => {
         let aligned : bool =
@@ -62,12 +62,12 @@ function clause execute(LOADRES(aq, rl, rs1, width, rd)) = {
          */
         if (~ (aligned))
         then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
-        else match translateAddr(vaddr, Read(Data)) {
+        else match translateAddr(vaddr, Read(RData)) {
                TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
                TR_Address(addr, _) =>
                  match (width, sizeof(xlen)) {
-                   (WORD, _)    => process_loadres(rd, vaddr, mem_read(Read(Data), addr, 4, aq, rl, true), false),
-                   (DOUBLE, 64) => process_loadres(rd, vaddr, mem_read(Read(Data), addr, 8, aq, rl, true), false),
+                   (WORD, _)    => process_loadres(rd, vaddr, mem_read(Read(RData), addr, 4, aq, rl, true), false),
+                   (DOUBLE, 64) => process_loadres(rd, vaddr, mem_read(Read(RData), addr, 8, aq, rl, true), false),
                    _            => internal_error("LOADRES expected WORD or DOUBLE")
                  }
              }
@@ -103,7 +103,7 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
       /* Get the address, X(rs1) (no offset).
        * Extensions might perform additional checks on address validity.
        */
-      match ext_data_get_addr(rs1, zeros(), Write(Data), width) {
+      match ext_data_get_addr(rs1, zeros(), Write(WData), width) {
         Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
         Ext_DataAddr_OK(vaddr) => {
           let aligned : bool =
@@ -123,8 +123,8 @@ function clause execute (STORECON(aq, rl, rs2, rs1, width, rd)) = {
               /* cannot happen in rmem */
               X(rd) = EXTZ(0b1); cancel_reservation(); RETIRE_SUCCESS
             } else {
-              match translateAddr(vaddr, Write(Data)) {  /* Write and ReadWrite are equivalent here:
-                                                          * both result in a SAMO exception */
+              match translateAddr(vaddr, Write(WData)) {  /* Write and ReadWrite are equivalent here:
+                                                           * both result in a SAMO exception */
                 TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
                 TR_Address(addr, _) => {
                   let eares : MemoryOpResult(unit) = match (width, sizeof(xlen)) {
@@ -189,10 +189,10 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
     /* Get the address, X(rs1) (no offset).
      * Some extensions perform additional checks on address validity.
      */
-    match ext_data_get_addr(rs1, zeros(), ReadWrite(Data), width) {
+    match ext_data_get_addr(rs1, zeros(), ReadWrite(RData,WData), width) {
       Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
       Ext_DataAddr_OK(vaddr) => {
-        match translateAddr(vaddr, ReadWrite(Data)) {
+        match translateAddr(vaddr, ReadWrite(RData,WData)) {
           TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
           TR_Address(addr, _) => {
             let eares : MemoryOpResult(unit) = match (width, sizeof(xlen)) {
@@ -214,8 +214,8 @@ function clause execute (AMO(op, aq, rl, rs2, rs1, width, rd)) = {
               MemException(e) => { handle_mem_exception(addr, e); RETIRE_FAIL },
               MemValue(_) => {
                 let mval : MemoryOpResult(xlenbits) = match (width, sizeof(xlen)) {
-                  (WORD, _)    => extend_value(is_unsigned, mem_read(ReadWrite(Data), addr, 4, aq, aq & rl, true)),
-                  (DOUBLE, 64) => extend_value(is_unsigned, mem_read(ReadWrite(Data), addr, 8, aq, aq & rl, true)),
+                  (WORD, _)    => extend_value(is_unsigned, mem_read(ReadWrite(RData,WData), addr, 4, aq, aq & rl, true)),
+                  (DOUBLE, 64) => extend_value(is_unsigned, mem_read(ReadWrite(RData,WData), addr, 8, aq, aq & rl, true)),
                   _            => internal_error("AMO expected WORD or DOUBLE")
                 };
                 match (mval) {

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -318,23 +318,23 @@ function clause execute(LOAD(imm, rs1, rd, is_unsigned, width, aq, rl)) = {
   let offset : xlenbits = EXTS(imm);
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Read(Data), width) {
+  match ext_data_get_addr(rs1, offset, Read(RData), width) {
     Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
     Ext_DataAddr_OK(vaddr) =>
       if   check_misaligned(vaddr, width)
       then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
-      else match translateAddr(vaddr, Read(Data)) {
+      else match translateAddr(vaddr, Read(RData)) {
         TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(paddr, _) =>
           match (width, sizeof(xlen)) {
             (BYTE, _)   =>
-               process_load(rd, vaddr, mem_read(Read(Data), paddr, 1, aq, rl, false), is_unsigned),
+               process_load(rd, vaddr, mem_read(Read(RData), paddr, 1, aq, rl, false), is_unsigned),
             (HALF, _)   =>
-               process_load(rd, vaddr, mem_read(Read(Data), paddr, 2, aq, rl, false), is_unsigned),
+               process_load(rd, vaddr, mem_read(Read(RData), paddr, 2, aq, rl, false), is_unsigned),
             (WORD, _)   =>
-               process_load(rd, vaddr, mem_read(Read(Data), paddr, 4, aq, rl, false), is_unsigned),
+               process_load(rd, vaddr, mem_read(Read(RData), paddr, 4, aq, rl, false), is_unsigned),
             (DOUBLE, 64) =>
-               process_load(rd, vaddr, mem_read(Read(Data), paddr, 8, aq, rl, false), is_unsigned)
+               process_load(rd, vaddr, mem_read(Read(RData), paddr, 8, aq, rl, false), is_unsigned)
           }
       }
   }
@@ -373,12 +373,12 @@ function clause execute (STORE(imm, rs2, rs1, width, aq, rl)) = {
   let offset : xlenbits = EXTS(imm);
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Write(Data), width) {
+  match ext_data_get_addr(rs1, offset, Write(WData), width) {
     Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
     Ext_DataAddr_OK(vaddr) =>
       if   check_misaligned(vaddr, width)
       then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
-      else match translateAddr(vaddr, Write(Data)) {
+      else match translateAddr(vaddr, Write(WData)) {
         TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(paddr, _) => {
           let eares : MemoryOpResult(unit) = match width {

--- a/model/riscv_insts_fext.sail
+++ b/model/riscv_insts_fext.sail
@@ -319,12 +319,12 @@ function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
   let offset : xlenbits = EXTS(imm);
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Read(Data), width) {
+  match ext_data_get_addr(rs1, offset, Read(RData), width) {
     Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
     Ext_DataAddr_OK(vaddr) =>
       if   check_misaligned(vaddr, width)
       then { handle_mem_exception(vaddr, E_Load_Addr_Align()); RETIRE_FAIL }
-      else match translateAddr(vaddr, Read(Data)) {
+      else match translateAddr(vaddr, Read(RData)) {
         TR_Failure(e, _) => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(addr, _) => {
           let (aq, rl, res) = (false, false, false);
@@ -332,9 +332,9 @@ function clause execute(LOAD_FP(imm, rs1, rd, width)) = {
             (BYTE, _)   => { handle_illegal(); RETIRE_FAIL },
             (HALF, _)   => { handle_illegal(); RETIRE_FAIL },
             (WORD, _)   =>
-               process_fload32(rd, vaddr, mem_read(Read(Data), addr, 4, aq, rl, res)),
+               process_fload32(rd, vaddr, mem_read(Read(RData), addr, 4, aq, rl, res)),
             (DOUBLE, 64) =>
-               process_fload64(rd, vaddr, mem_read(Read(Data), addr, 8, aq, rl, res))
+               process_fload64(rd, vaddr, mem_read(Read(RData), addr, 8, aq, rl, res))
           }
         }
       }
@@ -380,12 +380,12 @@ function clause execute (STORE_FP(imm, rs2, rs1, width)) = {
   let (aq, rl, con) = (false, false, false);
   /* Get the address, X(rs1) + offset.
      Some extensions perform additional checks on address validity. */
-  match ext_data_get_addr(rs1, offset, Write(Data), width) {
+  match ext_data_get_addr(rs1, offset, Write(WData), width) {
     Ext_DataAddr_Error(e)  => { ext_handle_data_check_error(e); RETIRE_FAIL },
     Ext_DataAddr_OK(vaddr) =>
       if   check_misaligned(vaddr, width)
       then { handle_mem_exception(vaddr, E_SAMO_Addr_Align()); RETIRE_FAIL }
-      else match translateAddr(vaddr, Write(Data)) {
+      else match translateAddr(vaddr, Write(WData)) {
         TR_Failure(e, _)    => { handle_mem_exception(vaddr, e); RETIRE_FAIL },
         TR_Address(addr, _) => {
           let eares : MemoryOpResult(unit) = match width {

--- a/model/riscv_iris.sail
+++ b/model/riscv_iris.sail
@@ -300,10 +300,10 @@ enum Retired = {RETIRE_SUCCESS, RETIRE_FAIL}
 
 /* memory access types */
 
-union AccessType ('a : Type) = {
-  Read      : 'a,
-  Write     : 'a,
-  ReadWrite : 'a,
+union AccessType ('r : Type, 'w : Type) = {
+  Read      : 'r,
+  Write     : 'w,
+  ReadWrite : ('r, 'w),
   Execute   : unit
 }
 
@@ -354,24 +354,7 @@ function word_width_bytes width = match width {
   WORD   => 4,
   DOUBLE => 8
 }
-// Extensions for memory Accesstype.
 
-type ext_access_type = unit
-
-let Data  : ext_access_type = ()
-
-let default_write_acc : ext_access_type = Data
-
-val accessType_to_str : AccessType(ext_access_type) -> string
-function accessType_to_str (a) =
-  match (a) {
-    Read(Data)      => "R",
-    Write(Data)     => "W",
-    ReadWrite(Data) => "RW",
-    Execute()       => "X"
-  }
-
-overload to_str = {accessType_to_str}
 /* default register type */
 type regtype = xlenbits
 
@@ -654,7 +637,9 @@ type ext_data_addr_error = unit
 
 /* Default data addr is just base register + immediate offset (may be zero).
    Extensions might override and add additional checks. */
-function ext_data_get_addr(base : regidx, offset : xlenbits, acc : AccessType(ext_access_type), width : word_width)
+function ext_data_get_addr(base : regidx, offset : xlenbits,
+                           acc : AccessType(ext_access_type_r, ext_access_type_w),
+                           width : word_width)
          -> Ext_DataAddr_Check(ext_data_addr_error) =
   let addr = X(base) + offset in
   Ext_DataAddr_OK(addr)
@@ -749,7 +734,10 @@ function read_kind_of_flags (aq : bool, rl : bool, res : bool) -> option(read_ki
   }
 
 // only used for actual memory regions, to avoid MMIO effects
-function phys_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_access_type), paddr : xlenbits, width : atom('n), aq : bool, rl: bool, res : bool, meta : bool) -> MemoryOpResult((bits(8 * 'n), mem_meta)) = {
+function phys_mem_read forall 'n, 0 < 'n <= max_mem_access .
+         (t : AccessType(ext_access_type_r, ext_access_type_w),
+          paddr : xlenbits, width : atom('n), aq : bool, rl: bool, res : bool, meta : bool)
+         -> MemoryOpResult((bits(8 * 'n), mem_meta)) = {
   let result = (match read_kind_of_flags(aq, rl, res) {
     Some(rk) => Some(read_ram(rk, paddr, width, meta)),
     None()   => None()
@@ -762,7 +750,11 @@ function phys_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext
   }
 }
 
-val mem_read      : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), xlenbits, atom('n), bool, bool, bool) -> MemoryOpResult(bits(8 * 'n))             effect {rmem, rmemt, rreg, escape}
+val mem_read      : forall 'n, 0 < 'n <= max_mem_access .
+                    (AccessType(ext_access_type_r, ext_access_type_w),
+                     xlenbits, atom('n), bool, bool, bool)
+                    -> MemoryOpResult(bits(8 * 'n))
+                    effect {rmem, rmemt, rreg, escape}
 
 function mem_read (typ, paddr, width, aq, rl, res) = {
  let result : MemoryOpResult(bits(8 * 'n)) =
@@ -837,7 +829,9 @@ union TR_Result('paddr : Type, 'failure : Type) = {
   TR_Failure : ('failure, ext_ptw)
 }
 
-val translateAddr : (xlenbits, AccessType(ext_access_type)) -> TR_Result(xlenbits, ExceptionType) effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
+val translateAddr : (xlenbits, AccessType(ext_access_type_r,ext_access_type_w))
+                    -> TR_Result(xlenbits, ExceptionType)
+                    effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
 function translateAddr(vAddr, ac) = {
   TR_Address(vAddr, ());
 }

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -32,7 +32,10 @@ function read_kind_of_flags (aq : bool, rl : bool, res : bool) -> option(read_ki
   }
 
 // only used for actual memory regions, to avoid MMIO effects
-function phys_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_access_type), paddr : xlenbits, width : atom('n), aq : bool, rl: bool, res : bool, meta : bool) -> MemoryOpResult((bits(8 * 'n), mem_meta)) = {
+function phys_mem_read forall 'n, 0 < 'n <= max_mem_access .
+         (t : AccessType(ext_access_type_r,ext_access_type_w),
+          paddr : xlenbits, width : atom('n), aq : bool, rl: bool, res : bool, meta : bool)
+         -> MemoryOpResult((bits(8 * 'n), mem_meta)) = {
   let result = (match read_kind_of_flags(aq, rl, res) {
     Some(rk) => Some(read_ram(rk, paddr, width, meta)),
     None()   => None()
@@ -48,7 +51,10 @@ function phys_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext
 }
 
 /* dispatches to MMIO regions or physical memory regions depending on physical memory map */
-function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_access_type), paddr : xlenbits, width : atom('n), aq : bool, rl : bool, res: bool, meta : bool) -> MemoryOpResult((bits(8 * 'n), mem_meta)) =
+function checked_mem_read forall 'n, 0 < 'n <= max_mem_access .
+         (t : AccessType(ext_access_type_r,ext_access_type_w),
+          paddr : xlenbits, width : atom('n), aq : bool, rl : bool, res: bool, meta : bool)
+         -> MemoryOpResult((bits(8 * 'n), mem_meta)) =
   if   within_mmio_readable(paddr, width)
   then MemoryOpResult_add_meta(mmio_read(t, paddr, width), default_meta)
   else if within_phys_mem(paddr, width)
@@ -60,7 +66,10 @@ function checked_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(
   }
 
 /* PMP checks if enabled */
-function pmp_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_access_type), paddr : xlenbits, width : atom('n), aq : bool, rl : bool, res: bool, meta : bool) -> MemoryOpResult((bits(8 * 'n), mem_meta)) =
+function pmp_mem_read forall 'n, 0 < 'n <= max_mem_access .
+         (t : AccessType(ext_access_type_r,ext_access_type_w),
+          paddr : xlenbits, width : atom('n), aq : bool, rl : bool, res: bool, meta : bool)
+         -> MemoryOpResult((bits(8 * 'n), mem_meta)) =
   if   (~ (plat_enable_pmp ()))
   then checked_mem_read(t, paddr, width, aq, rl, res, meta)
   else {
@@ -92,11 +101,32 @@ $endif
 
 /* NOTE: The rreg effect is due to MMIO. */
 $ifdef RVFI_DII
-val mem_read      : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), xlenbits, atom('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))             effect {wreg, rmem, rmemt, rreg, escape}
-val mem_read_meta : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), xlenbits, atom('n), bool, bool, bool, bool) -> MemoryOpResult((bits(8 * 'n), mem_meta)) effect {wreg, rmem, rmemt, rreg, escape}
+
+val mem_read      : forall 'n, 0 < 'n <= max_mem_access .
+                    (AccessType(ext_access_type_r,ext_access_type_w),
+                     xlenbits, atom('n), bool, bool, bool)
+                    -> MemoryOpResult(bits(8 * 'n))
+                    effect {wreg, rmem, rmemt, rreg, escape}
+
+val mem_read_meta : forall 'n, 0 < 'n <= max_mem_access .
+                    (AccessType(ext_access_type_r,ext_access_type_w),
+                     xlenbits, atom('n), bool, bool, bool, bool)
+                    -> MemoryOpResult((bits(8 * 'n), mem_meta))
+                    effect {wreg, rmem, rmemt, rreg, escape}
 $else
-val mem_read      : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), xlenbits, atom('n), bool, bool, bool)       -> MemoryOpResult(bits(8 * 'n))             effect {rmem, rmemt, rreg, escape}
-val mem_read_meta : forall 'n, 0 < 'n <= max_mem_access . (AccessType(ext_access_type), xlenbits, atom('n), bool, bool, bool, bool) -> MemoryOpResult((bits(8 * 'n), mem_meta)) effect {rmem, rmemt, rreg, escape}
+
+val mem_read      : forall 'n, 0 < 'n <= max_mem_access .
+                    (AccessType(ext_access_type_r,ext_access_type_w),
+                     xlenbits, atom('n), bool, bool, bool)
+                    -> MemoryOpResult(bits(8 * 'n))
+                    effect {rmem, rmemt, rreg, escape}
+
+val mem_read_meta : forall 'n, 0 < 'n <= max_mem_access .
+                    (AccessType(ext_access_type_r,ext_access_type_w),
+                     xlenbits, atom('n), bool, bool, bool, bool)
+                    -> MemoryOpResult((bits(8 * 'n), mem_meta))
+                    effect {rmem, rmemt, rreg, escape}
+
 $endif
 
 function mem_read_meta (typ, paddr, width, aq, rl, res, meta) = {
@@ -167,11 +197,11 @@ function checked_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk : write_kin
   else MemException(E_SAMO_Access_Fault())
 
 /* PMP checks if enabled */
-function pmp_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk: write_kind, paddr : xlenbits, width : atom('n), data: bits(8 * 'n), ext_acc: ext_access_type, meta: mem_meta) -> MemoryOpResult(bool) =
+function pmp_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk: write_kind, paddr : xlenbits, width : atom('n), data: bits(8 * 'n), ext_acc: ext_access_type_w, meta: mem_meta) -> MemoryOpResult(bool) =
   if   (~ (plat_enable_pmp ()))
   then checked_mem_write(wk, paddr, width, data, meta)
   else {
-    let typ : AccessType(ext_access_type) = Write(ext_acc);
+    let typ : AccessType(ext_access_type_r,ext_access_type_w) = Write(ext_acc);
     match pmpCheck(paddr, width, typ, effectivePrivilege(typ, mstatus, cur_privilege)) {
       None()  => checked_mem_write(wk, paddr, width, data, meta),
       Some(e) => MemException(e)
@@ -185,7 +215,7 @@ function pmp_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk: write_kind, pa
  * data.
  * NOTE: The wreg effect is due to MMIO, the rreg is due to checking mtime.
  */
-val mem_write_value_meta : forall 'n, 0 < 'n <= max_mem_access . (xlenbits, atom('n), bits(8 * 'n), ext_access_type, mem_meta, bool, bool, bool) -> MemoryOpResult(bool) effect {wmv, wmvt, rreg, wreg, escape}
+val mem_write_value_meta : forall 'n, 0 < 'n <= max_mem_access . (xlenbits, atom('n), bits(8 * 'n), ext_access_type_w, mem_meta, bool, bool, bool) -> MemoryOpResult(bool) effect {wmv, wmvt, rreg, wreg, escape}
 function mem_write_value_meta (paddr, width, value, ext_acc, meta, aq, rl, con) = {
   rvfi_write(paddr, width, value);
   if (rl | con) & (~ (is_aligned_addr(paddr, width)))

--- a/model/riscv_platform.sail
+++ b/model/riscv_platform.sail
@@ -142,7 +142,11 @@ let MTIMECMP_BASE_HI : xlenbits = EXTZ(0x04004)
 let MTIME_BASE       : xlenbits = EXTZ(0x0bff8)
 let MTIME_BASE_HI    : xlenbits = EXTZ(0x0bffc)
 
-val clint_load : forall 'n, 'n > 0. (AccessType(ext_access_type), xlenbits, int('n)) -> MemoryOpResult(bits(8 * 'n)) effect {rreg}
+val clint_load : forall 'n, 'n > 0.
+                 (AccessType(ext_access_type_r,ext_access_type_w),
+                  xlenbits, int('n))
+                 -> MemoryOpResult(bits(8 * 'n))
+                 effect {rreg}
 function clint_load(t, addr, width) = {
   let addr = addr - plat_clint_base ();
   /* FIXME: For now, only allow exact aligned access. */
@@ -280,7 +284,11 @@ register htif_exit_code : bits(64)
  * dispatched the address.
  */
 
-val htif_load : forall 'n, 'n > 0. (AccessType(ext_access_type), xlenbits, int('n)) -> MemoryOpResult(bits(8 * 'n)) effect {rreg}
+val htif_load : forall 'n, 'n > 0.
+                (AccessType(ext_access_type_r,ext_access_type_w),
+                 xlenbits, int('n))
+                -> MemoryOpResult(bits(8 * 'n))
+                effect {rreg}
 function htif_load(t, paddr, width) = {
   if   get_config_print_platform()
   then print_platform("htif[" ^ BitStr(paddr) ^ "] -> " ^ BitStr(htif_tohost));
@@ -361,7 +369,10 @@ $else
 function within_mmio_writable forall 'n, 0 < 'n <= max_mem_access . (addr : xlenbits, width : atom('n)) -> bool = false
 $endif
 
-function mmio_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_access_type), paddr : xlenbits, width : atom('n)) -> MemoryOpResult(bits(8 * 'n)) =
+function mmio_read forall 'n, 0 < 'n <= max_mem_access .
+         (t : AccessType(ext_access_type_r,ext_access_type_w),
+          paddr : xlenbits, width : atom('n))
+         -> MemoryOpResult(bits(8 * 'n)) =
   if   within_clint(paddr, width)
   then clint_load(t, paddr, width)
   else if within_htif_readable(paddr, width) & (1 <= 'n)

--- a/model/riscv_pmp_control.sail
+++ b/model/riscv_pmp_control.sail
@@ -26,7 +26,7 @@ function pmpAddrRange(cfg: Pmpcfg_ent, pmpaddr: xlenbits, prev_pmpaddr: xlenbits
 
 /* permission checks */
 
-val pmpCheckRWX: (Pmpcfg_ent, AccessType(ext_access_type)) -> bool
+val pmpCheckRWX: (Pmpcfg_ent, AccessType(ext_access_type_r,ext_access_type_w)) -> bool
 function pmpCheckRWX(ent, acc) = {
   match acc {
     Read(Data)      => ent.R() == 0b1,
@@ -37,7 +37,7 @@ function pmpCheckRWX(ent, acc) = {
 }
 
 // this needs to be called with the effective current privilege.
-val pmpCheckPerms: (Pmpcfg_ent, AccessType(ext_access_type), Privilege) -> bool
+val pmpCheckPerms: (Pmpcfg_ent, AccessType(ext_access_type_r,ext_access_type_w), Privilege) -> bool
 function pmpCheckPerms(ent, acc, priv) = {
   match priv {
     Machine => if   pmpLocked(ent)
@@ -68,8 +68,11 @@ function pmpMatchAddr(addr: xlenbits, width: xlenbits, rng: pmp_addr_range) -> p
 
 enum pmpMatch = {PMP_Success, PMP_Continue, PMP_Fail}
 
-function pmpMatchEntry(addr: xlenbits, width: xlenbits, acc: AccessType(ext_access_type), priv: Privilege,
-                       ent: Pmpcfg_ent, pmpaddr: xlenbits, prev_pmpaddr: xlenbits) -> pmpMatch = {
+function pmpMatchEntry(addr: xlenbits, width: xlenbits,
+                       acc: AccessType(ext_access_type_r,ext_access_type_w),
+                       priv: Privilege, ent: Pmpcfg_ent, pmpaddr: xlenbits,
+                       prev_pmpaddr: xlenbits)
+                      -> pmpMatch = {
   let rng = pmpAddrRange(ent, pmpaddr, prev_pmpaddr);
   match pmpMatchAddr(addr, width, rng) {
     PMP_NoMatch      => PMP_Continue,
@@ -82,8 +85,10 @@ function pmpMatchEntry(addr: xlenbits, width: xlenbits, acc: AccessType(ext_acce
 
 /* priority checks */
 
-function pmpCheck forall 'n, 'n > 0. (addr: xlenbits, width: atom('n), acc: AccessType(ext_access_type), priv: Privilege)
-                  -> option(ExceptionType) = {
+function pmpCheck forall 'n, 'n > 0.
+         (addr: xlenbits, width: atom('n),
+          acc: AccessType(ext_access_type_r,ext_access_type_w), priv: Privilege)
+         -> option(ExceptionType) = {
   let width : xlenbits = to_bits(sizeof(xlen), width);
   let check : bool =
   match pmpMatchEntry(addr, width, acc, priv, pmp0cfg, pmpaddr0, zeros()) {

--- a/model/riscv_pte.sail
+++ b/model/riscv_pte.sail
@@ -40,7 +40,10 @@ function to_pte_check(b : bool) -> PTE_Check =
  * and the accumulated information of the page-table-walk in ext_ptw.  It should return
  * the updated ext_ptw in both the success and failure cases.
  */
-function checkPTEPermission(ac : AccessType(ext_access_type), priv : Privilege, mxr : bool, do_sum : bool, p : PTE_Bits, ext : extPte, ext_ptw : ext_ptw) -> PTE_Check = {
+function checkPTEPermission(ac : AccessType(ext_access_type_r,ext_access_type_w),
+                            priv : Privilege, mxr : bool, do_sum : bool, p : PTE_Bits,
+                            ext : extPte, ext_ptw : ext_ptw)
+                           -> PTE_Check = {
   match (ac, priv) {
     (Read(Data),      User)       => to_pte_check(p.U() == 0b1 & (p.R() == 0b1 | (p.X() == 0b1 & mxr))),
     (Write(Data),     User)       => to_pte_check(p.U() == 0b1 & p.W() == 0b1),
@@ -56,9 +59,22 @@ function checkPTEPermission(ac : AccessType(ext_access_type), priv : Privilege, 
   }
 }
 
-function update_PTE_Bits(p : PTE_Bits, a : AccessType(ext_access_type), ext : extPte) -> option((PTE_Bits, extPte)) = {
-  let update_d = (a == Write(Data) | a == ReadWrite(Data)) & p.D() == 0b0; // dirty-bit
-  let update_a = p.A() == 0b0;                                             // accessed-bit
+function update_PTE_Bits(p : PTE_Bits,
+                         a : AccessType(ext_access_type_r,ext_access_type_w),
+                         ext : extPte)
+                        -> option((PTE_Bits, extPte)) = {
+
+  // dirty bit
+  let update_d = p.D() == 0b0 & (match a {
+                                  Execute()      => false,
+                                  Read(_)        => false,
+                                  Write(_)     => true,
+                                  ReadWrite(_) => true
+                                });
+
+  // accessed bit
+  let update_a = p.A() == 0b0;
+
   if update_d | update_a then {
     let np = update_A(p, 0b1);
     let np = if update_d then update_D(np, 0b1) else np;

--- a/model/riscv_ptw.sail
+++ b/model/riscv_ptw.sail
@@ -23,7 +23,9 @@ function ptw_error_to_str(e) =
 overload to_str = {ptw_error_to_str}
 
 /* conversion of these translation/PTW failures into architectural exceptions */
-function translationException(a : AccessType(ext_access_type), f : PTW_Error) -> ExceptionType = {
+function translationException(a : AccessType(ext_access_type_r,ext_access_type_w),
+                              f : PTW_Error)
+                             -> ExceptionType = {
   let e : ExceptionType =
   match (a, f) {
     (_, PTW_Ext_Error(e))           => E_Extension(ext_translate_exception(e)),

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -141,7 +141,9 @@ bitfield Mstatus : xlenbits = {
 }
 register mstatus : Mstatus
 
-function effectivePrivilege(t : AccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
+function effectivePrivilege(t : AccessType(ext_access_type_r,ext_access_type_w),
+                            m : Mstatus, priv : Privilege)
+                           -> Privilege =
   if   t != Execute() & m.MPRV() == 0b1
   then privLevel_of_bits(mstatus.MPP())
   else cur_privilege

--- a/model/riscv_types.sail
+++ b/model/riscv_types.sail
@@ -97,10 +97,10 @@ enum Retired = {RETIRE_SUCCESS, RETIRE_FAIL}
 
 /* memory access types */
 
-union AccessType ('a : Type) = {
-  Read      : 'a,
-  Write     : 'a,
-  ReadWrite : 'a,
+union AccessType ('r : Type, 'w : Type) = {
+  Read      : 'r,
+  Write     : 'w,
+  ReadWrite : ('r, 'w),
   Execute   : unit
 }
 

--- a/model/riscv_vmem_rv32.sail
+++ b/model/riscv_vmem_rv32.sail
@@ -26,7 +26,10 @@ function translationMode(priv) = {
 
 /* Top-level address translation dispatcher */
 
-val translateAddr : (xlenbits, AccessType(ext_access_type)) -> TR_Result(xlenbits, ExceptionType) effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
+val translateAddr : (xlenbits,
+                     AccessType(ext_access_type_r,ext_access_type_w))
+                    -> TR_Result(xlenbits, ExceptionType)
+                    effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
 function translateAddr(vAddr, ac) = {
   let effPriv : Privilege = effectivePrivilege(ac, mstatus, cur_privilege);
   let mxr    : bool   = mstatus.MXR() == 0b1;

--- a/model/riscv_vmem_rv64.sail
+++ b/model/riscv_vmem_rv64.sail
@@ -33,7 +33,10 @@ function translationMode(priv) = {
 
 /* Top-level address translation dispatcher */
 
-val translateAddr : (xlenbits, AccessType(ext_access_type)) -> TR_Result(xlenbits, ExceptionType) effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
+val translateAddr : (xlenbits,
+                     AccessType(ext_access_type_r,ext_access_type_w))
+                    -> TR_Result(xlenbits, ExceptionType)
+                    effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
 function translateAddr(vAddr, ac) = {
   let effPriv : Privilege = effectivePrivilege(ac, mstatus, cur_privilege);
   let mxr    : bool   = mstatus.MXR() == 0b1;

--- a/model/riscv_vmem_sv32.sail
+++ b/model/riscv_vmem_sv32.sail
@@ -6,7 +6,11 @@
 
 function to_phys_addr(a : paddr32) -> xlenbits = a[31..0]
 
-val walk32 : (vaddr32, AccessType(ext_access_type), Privilege, bool, bool, paddr32, nat, bool, ext_ptw) -> PTW_Result(paddr32, SV32_PTE) effect {rmem, rmemt, rreg, escape}
+val walk32 : (vaddr32,
+              AccessType(ext_access_type_r,ext_access_type_w),
+              Privilege, bool, bool, paddr32, nat, bool, ext_ptw)
+             -> PTW_Result(paddr32, SV32_PTE)
+             effect {rmem, rmemt, rreg, escape}
 function walk32(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
   let va = Mk_SV32_Vaddr(vaddr);
   let pt_ofs : paddr32 = shiftl(EXTZ(shiftr(va.VPNi(), (level * SV32_LEVEL_BITS))[(SV32_LEVEL_BITS - 1) .. 0]),
@@ -115,7 +119,11 @@ function flush_TLB32(asid, addr) =
 
 /* address translation */
 
-val translate32 : (asid32, paddr32, vaddr32, AccessType(ext_access_type), Privilege, bool, bool, nat, ext_ptw) -> TR_Result(paddr32, PTW_Error) effect {rreg, wreg, wmv, wmvt, escape, rmem, rmemt}
+val translate32 : (asid32, paddr32, vaddr32,
+                   AccessType(ext_access_type_r,ext_access_type_w),
+                   Privilege, bool, bool, nat, ext_ptw)
+                  -> TR_Result(paddr32, PTW_Error)
+                  effect {rreg, wreg, wmv, wmvt, escape, rmem, rmemt}
 function translate32(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = {
   match lookup_TLB32(asid, vAddr) {
     Some(idx, ent) => {

--- a/model/riscv_vmem_sv39.sail
+++ b/model/riscv_vmem_sv39.sail
@@ -1,6 +1,10 @@
 /* Sv39 address translation for RV64. */
 
-val walk39 : (vaddr39, AccessType(ext_access_type), Privilege, bool, bool, paddr64, nat, bool, ext_ptw) -> PTW_Result(paddr64, SV39_PTE) effect {rmem, rmemt, rreg, escape}
+val walk39 : (vaddr39,
+              AccessType(ext_access_type_r,ext_access_type_w),
+              Privilege, bool, bool, paddr64, nat, bool, ext_ptw)
+             -> PTW_Result(paddr64, SV39_PTE)
+             effect {rmem, rmemt, rreg, escape}
 function walk39(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
   let va = Mk_SV39_Vaddr(vaddr);
   let pt_ofs : paddr64 = shiftl(EXTZ(shiftr(va.VPNi(), (level * SV39_LEVEL_BITS))[(SV39_LEVEL_BITS - 1) .. 0]),
@@ -109,7 +113,11 @@ function flush_TLB39(asid, addr) =
 
 /* address translation */
 
-val translate39 : (asid64, paddr64, vaddr39, AccessType(ext_access_type), Privilege, bool, bool, nat, ext_ptw) -> TR_Result(paddr64, PTW_Error) effect {rreg, wreg, wmv, wmvt, escape, rmem, rmemt}
+val translate39 : (asid64, paddr64, vaddr39,
+                   AccessType(ext_access_type_r,ext_access_type_w),
+                   Privilege, bool, bool, nat, ext_ptw)
+                  -> TR_Result(paddr64, PTW_Error)
+                  effect {rreg, wreg, wmv, wmvt, escape, rmem, rmemt}
 function translate39(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = {
   match lookup_TLB39(asid, vAddr) {
     Some(idx, ent) => {

--- a/model/riscv_vmem_sv48.sail
+++ b/model/riscv_vmem_sv48.sail
@@ -1,6 +1,10 @@
 /* Sv48 address translation for RV64. */
 
-val walk48 : (vaddr48, AccessType(ext_access_type), Privilege, bool, bool, paddr64, nat, bool, ext_ptw) -> PTW_Result(paddr64, SV48_PTE) effect {rmem, rmemt, rreg, escape}
+val walk48 : (vaddr48,
+              AccessType(ext_access_type_r,ext_access_type_w),
+              Privilege, bool, bool, paddr64, nat, bool, ext_ptw)
+             -> PTW_Result(paddr64, SV48_PTE)
+             effect {rmem, rmemt, rreg, escape}
 function walk48(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
   let va = Mk_SV48_Vaddr(vaddr);
   let pt_ofs : paddr64 = shiftl(EXTZ(shiftr(va.VPNi(), (level * SV48_LEVEL_BITS))[(SV48_LEVEL_BITS - 1) .. 0]),
@@ -109,7 +113,11 @@ function flush_TLB48(asid, addr) =
 
 /* address translation */
 
-val translate48 : (asid64, paddr64, vaddr48, AccessType(ext_access_type), Privilege, bool, bool, nat, ext_ptw) -> TR_Result(paddr64, PTW_Error) effect {rreg, wreg, wmv, wmvt, escape, rmem, rmemt}
+val translate48 : (asid64, paddr64, vaddr48,
+                   AccessType(ext_access_type_r,ext_access_type_w),
+                   Privilege, bool, bool, nat, ext_ptw)
+                  -> TR_Result(paddr64, PTW_Error)
+                  effect {rreg, wreg, wmv, wmvt, escape, rmem, rmemt}
 function translate48(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = {
   match walk48(vAddr, ac, priv, mxr, do_sum, ptb, level, false, ext_ptw) {
     PTW_Failure(f, ext_ptw) => TR_Failure(f, ext_ptw),

--- a/model/riscv_vmem_types.sail
+++ b/model/riscv_vmem_types.sail
@@ -1,18 +1,20 @@
 // Extensions for memory Accesstype.
 
-type ext_access_type = unit
+type ext_access_type_r = unit
+type ext_access_type_w = unit
 
-let Data  : ext_access_type = ()
+let RData  : ext_access_type_r = ()
+let WData  : ext_access_type_w = ()
 
-let default_write_acc : ext_access_type = Data
+let default_write_acc : ext_access_type_w = WData
 
-val accessType_to_str : AccessType(ext_access_type) -> string
+val accessType_to_str : AccessType(ext_access_type_r, ext_access_type_w) -> string
 function accessType_to_str (a) =
   match (a) {
-    Read(Data)      => "R",
-    Write(Data)     => "W",
-    ReadWrite(Data) => "RW",
-    Execute()       => "X"
+    Read(Data)           => "R",
+    Write(Data)          => "W",
+    ReadWrite(Data,Data) => "RW",
+    Execute()            => "X"
   }
 
 overload to_str = {accessType_to_str}


### PR DESCRIPTION
On CHERI, we're seemingly going to want to signal our load preparedness for capabilities and whether or not our stores transit capabilities separately as part of the capability-gating bits in the PTEs.  This may also be otherwise useful?  Or it could be junk!