### PR TITLE
SV32: allow external specification of PTE extension bits

### DIFF
--- a/model/riscv_pte.sail
+++ b/model/riscv_pte.sail
@@ -7,6 +7,17 @@ type pteAttribs = bits(8)
  */
 type extPte = bits(10)
 
+/*
+ * On SV32, there are no reserved bits available to extensions.  Therefore, by
+ * default, we initialize the PTE extension field with all zeros.  However,
+ * extensions may wish, on SV39/48/56, to put flags in the reserved region of
+ * those PTEs.  To avoid the need for "inhibit" bits in extensions (i.e., so
+ * that extensions can use the more common and more RISC-V flavored "enable"
+ * disposition), we allow extensions to use any constant value by overriding
+ * this default_sv32_ext_pte value.
+ */
+let default_sv32_ext_pte : extPte = zeros()
+
 bitfield PTE_Bits : pteAttribs = {
   D : 7,
   A : 6,

--- a/model/riscv_vmem_sv32.sail
+++ b/model/riscv_vmem_sv32.sail
@@ -24,7 +24,7 @@ function walk32(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
     MemValue(v) => {
       let pte = Mk_SV32_PTE(v);
       let pbits = pte.BITS();
-      let ext_pte : extPte = zeros(); // no reserved bits for extensions
+      let ext_pte : extPte = default_sv32_ext_pte;
       let pattr = Mk_PTE_Bits(pbits);
       let is_global = global | (pattr.G() == 0b1);
 /*    print("walk32(vaddr=" ^ BitStr(vaddr) ^ " level=" ^ string_of_int(level)


### PR DESCRIPTION
Just because they're not present in the SV32 PTE doesn't mean that
models necessarily need to interpret them as zeros; any constant will do
just fine.  This allows extensions (like CHERI) that have both RV32 and
RV64 versions to define more standard idiomatic interpretation to the
bits within the PTE extension field.