### PR TITLE
Allow extensions to override page fault causes

### DIFF
--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -14,7 +14,9 @@
 #include "elf.h"
 #include "sail.h"
 #include "rts.h"
+#ifdef SAILCOV
 #include "sail_coverage.h"
+#endif
 #include "riscv_platform.h"
 #include "riscv_platform_impl.h"
 #include "riscv_sail.h"

--- a/model/riscv_ptw.sail
+++ b/model/riscv_ptw.sail
@@ -24,6 +24,9 @@ function ptw_error_to_str(e) =
 
 overload to_str = {ptw_error_to_str}
 
+function ext_get_ptw_error(ext_ptw : ext_ptw) -> PTW_Error =
+  PTW_No_Permission()
+
 /* conversion of these translation/PTW failures into architectural exceptions */
 function translationException(a : AccessType(ext_access_type), f : PTW_Error) -> ExceptionType = {
   let e : ExceptionType =

--- a/model/riscv_vmem_sv32.sail
+++ b/model/riscv_vmem_sv32.sail
@@ -49,7 +49,7 @@ function walk32(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
           match checkPTEPermission(ac, priv, mxr, do_sum, pattr, ext_pte, ext_ptw) {
             PTE_Check_Failure(ext_ptw) => {
 /*            print("walk32: pte permission check failure"); */
-              PTW_Failure(PTW_No_Permission(), ext_ptw)
+              PTW_Failure(ext_get_ptw_error(ext_ptw), ext_ptw)
             },
             PTE_Check_Success(ext_ptw) => {
               if level > 0 then { /* superpage */
@@ -124,7 +124,7 @@ function translate32(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
       let  ext_pte : extPte = zeros(); // no reserved bits for extensions
       let  pteBits = Mk_PTE_Bits(pte.BITS());
       match checkPTEPermission(ac, priv, mxr, do_sum, pteBits, ext_pte, ext_ptw) {
-        PTE_Check_Failure(ext_ptw) => { TR_Failure(PTW_No_Permission(), ext_ptw) },
+        PTE_Check_Failure(ext_ptw) => { TR_Failure(ext_get_ptw_error(ext_ptw), ext_ptw) },
         PTE_Check_Success(ext_ptw) => {
           match update_PTE_Bits(pteBits, ac, ext_pte) {
             None()           => TR_Address(ent.pAddr | EXTZ(vAddr & ent.vAddrMask), ext_ptw),

--- a/model/riscv_vmem_sv39.sail
+++ b/model/riscv_vmem_sv39.sail
@@ -43,7 +43,7 @@ function walk39(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
           match checkPTEPermission(ac, priv, mxr, do_sum, pattr, ext_pte, ext_ptw) {
 	    PTE_Check_Failure(ext_ptw) => {
 /*            print("walk39: pte permission check failure"); */
-              PTW_Failure(PTW_No_Permission(), ext_ptw)
+              PTW_Failure(ext_get_ptw_error(ext_ptw), ext_ptw)
             },
             PTE_Check_Success(ext_ptw)  => {
               if level > 0 then { /* superpage */
@@ -118,7 +118,7 @@ function translate39(asid, ptb, vAddr, ac, priv, mxr, do_sum, level, ext_ptw) = 
       let  ext_pte = pte.Ext();
       let  pteBits = Mk_PTE_Bits(pte.BITS());
       match checkPTEPermission(ac, priv, mxr, do_sum, pteBits, ext_pte, ext_ptw) {
-        PTE_Check_Failure(ext_ptw) => { TR_Failure(PTW_No_Permission(), ext_ptw) },
+        PTE_Check_Failure(ext_ptw) => { TR_Failure(ext_get_ptw_error(ext_ptw), ext_ptw) },
         PTE_Check_Success(ext_ptw) => {
           match update_PTE_Bits(pteBits, ac, ext_pte) {
             None()           => TR_Address(ent.pAddr | EXTZ(vAddr & ent.vAddrMask), ext_ptw),

--- a/model/riscv_vmem_sv48.sail
+++ b/model/riscv_vmem_sv48.sail
@@ -43,7 +43,7 @@ function walk48(vaddr, ac, priv, mxr, do_sum, ptb, level, global, ext_ptw) = {
           match checkPTEPermission(ac, priv, mxr, do_sum, pattr, ext_pte, ext_ptw) {
             PTE_Check_Failure(ext_ptw) => {
 /*            print("walk48: pte permission check failure"); */
-              PTW_Failure(PTW_No_Permission(), ext_ptw)
+              PTW_Failure(ext_get_ptw_error(ext_ptw), ext_ptw)
             },
 	    PTE_Check_Success(ext_ptw) => {
               if level > 0 then { /* superpage */


### PR DESCRIPTION
Otherwise there's no use for PTW_Ext_Error. This is required for sail-cheri-riscv to be able to make use of its own page table exceptions. The alternative to this is to pass the ext_ptw to translationException, but given PTW_Ext_Error exists it seems this was the intended way, and aligns with how access faults vs page faults are distinguished.