### PR TITLE
Add missing pieces to mcountinhibit CSR

### DIFF
--- a/model/riscv_csr_map.sail
+++ b/model/riscv_csr_map.sail
@@ -54,6 +54,7 @@ mapping clause csr_name_map = 0x303  <-> "mideleg"
 mapping clause csr_name_map = 0x304  <-> "mie"
 mapping clause csr_name_map = 0x305  <-> "mtvec"
 mapping clause csr_name_map = 0x306  <-> "mcounteren"
+mapping clause csr_name_map = 0x320  <-> "mcountinhibit"
 /* machine trap handling */
 mapping clause csr_name_map = 0x340  <-> "mscratch"
 mapping clause csr_name_map = 0x341  <-> "mepc"

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -21,6 +21,7 @@ function is_CSR_defined (csr : csreg, p : Privilege) -> bool =
     0x304 => p == Machine, // mie
     0x305 => p == Machine, // mtvec
     0x306 => p == Machine & haveUsrMode(), // mcounteren
+    0x320 => p == Machine, // mcountinhibit
     /* machine mode: trap handling */
     0x340 => p == Machine, // mscratch
     0x341 => p == Machine, // mepc

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -436,7 +436,8 @@ register minstret_written : bool
 function retire_instruction() -> unit = {
   if   minstret_written == true
   then minstret_written = false
-  else minstret = minstret + 1
+  else if mcountinhibit.IR() == 0b0
+       then minstret = minstret + 1
 }
 
 /* informational registers */


### PR DESCRIPTION
The `mcountinhibit` CSR was missing a mapping for the disassembler, and an entry in `is_CSR_defined()`. CSR read and write instructions to this CSR were taking an illegal instruction exception.

Update: also implemented the IR bit to squash increment of `minstret`.