### PR TITLE
Add support for the new RVFI_DII socket format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,9 +244,23 @@ rvfi: c_emulator/riscv_rvfi_$(ARCH)
 c_emulator/riscv_sim_$(ARCH): generated_definitions/c/riscv_model_$(ARCH).c $(C_INCS) $(C_SRCS) $(SOFTFLOAT_LIBS) Makefile
 	gcc -g $(C_WARNINGS) $(C_FLAGS) $< $(C_SRCS) $(SAIL_LIB_DIR)/*.c $(C_LIBS) -o $@
 
+# Note: We have to add -c_preserve since the functions might be optimized out otherwise
+rvfi_preserve_fns=-c_preserve rvfi_set_instr_packet \
+  -c_preserve rvfi_get_cmd \
+  -c_preserve rvfi_get_insn \
+  -c_preserve rvfi_get_v2_trace_size \
+  -c_preserve rvfi_get_v2_support_packet \
+  -c_preserve rvfi_get_exec_packet_v1 \
+  -c_preserve rvfi_get_exec_packet_v2 \
+  -c_preserve rvfi_zero_exec_packet \
+  -c_preserve rvfi_halt_exec_packet \
+  -c_preserve print_rvfi_exec \
+  -c_preserve print_instr_packet \
+  -c_preserve print_rvfi_exec
+
 generated_definitions/c/riscv_rvfi_model_$(ARCH).c: $(SAIL_RVFI_SRCS) model/main.sail Makefile
 	mkdir -p generated_definitions/c
-	$(SAIL) $(SAIL_FLAGS) -O -Oconstant_fold -memo_z3 -c -c_include riscv_prelude.h -c_include riscv_platform.h -c_no_main $(SAIL_RVFI_SRCS) model/main.sail -o $(basename $@)
+	$(SAIL) $(rvfi_preserve_fns) $(SAIL_FLAGS) -O -Oconstant_fold -memo_z3 -c -c_include riscv_prelude.h -c_include riscv_platform.h -c_no_main $(SAIL_RVFI_SRCS) model/main.sail -o $(basename $@)
 	sed -i -e '/^[[:space:]]*$$/d' $@
 
 c_emulator/riscv_rvfi_$(ARCH): generated_definitions/c/riscv_rvfi_model_$(ARCH).c $(C_INCS) $(C_SRCS) $(SOFTFLOAT_LIBS) Makefile

--- a/c_emulator/riscv_sail.h
+++ b/c_emulator/riscv_sail.h
@@ -33,6 +33,10 @@ void zrvfi_get_exec_packet_v1(sail_bits *rop, unit);
 void zrvfi_get_exec_packet_v2(sail_bits *rop, unit);
 mach_bits zrvfi_get_v2_trace_sizze(unit);
 void zrvfi_get_v2_support_packet(sail_bits *rop, unit);
+
+// Debugging prints
+unit zprint_rvfi_exec(unit);
+unit zprint_instr_packet(uint64_t);
 #endif
 
 extern mach_bits zxlen_val;

--- a/c_emulator/riscv_sail.h
+++ b/c_emulator/riscv_sail.h
@@ -25,10 +25,14 @@ unit z_set_Misa_F(struct zMisa*, mach_bits);
 unit zext_rvfi_init(unit);
 unit zrvfi_set_instr_packet(mach_bits);
 mach_bits zrvfi_get_cmd(unit);
+mach_bits zrvfi_get_insn(unit);
 bool zrvfi_step(sail_int);
 unit zrvfi_zzero_exec_packet(unit);
 unit zrvfi_halt_exec_packet(unit);
-void zrvfi_get_exec_packet(sail_bits *rop, unit);
+void zrvfi_get_exec_packet_v1(sail_bits *rop, unit);
+void zrvfi_get_exec_packet_v2(sail_bits *rop, unit);
+mach_bits zrvfi_get_v2_trace_sizze(unit);
+void zrvfi_get_v2_support_packet(sail_bits *rop, unit);
 #endif
 
 extern mach_bits zxlen_val;

--- a/c_emulator/riscv_sail.h
+++ b/c_emulator/riscv_sail.h
@@ -31,6 +31,10 @@ unit zrvfi_zzero_exec_packet(unit);
 unit zrvfi_halt_exec_packet(unit);
 void zrvfi_get_exec_packet_v1(sail_bits *rop, unit);
 void zrvfi_get_exec_packet_v2(sail_bits *rop, unit);
+extern bool zrvfi_int_data_present;
+void zrvfi_get_int_data(sail_bits *rop, unit);
+extern bool zrvfi_mem_data_present;
+void zrvfi_get_mem_data(sail_bits *rop, unit);
 mach_bits zrvfi_get_v2_trace_sizze(unit);
 void zrvfi_get_v2_support_packet(sail_bits *rop, unit);
 

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -710,7 +710,6 @@ static void get_and_send_rvfi_packet(packet_reader_fn *reader) {
 void rvfi_send_trace(unsigned version) {
   if (config_print_rvfi) {
     fprintf(stderr, "Sending v%d trace response...\n", version);
-    zprint_rvfi_exec(UNIT);
   }
   if (version == 1) {
     get_and_send_rvfi_packet(zrvfi_get_exec_packet_v1);

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -907,12 +907,12 @@ int main(int argc, char **argv)
     entry = 0x80000000;
     int listen_sock = socket(AF_INET, SOCK_STREAM, 0);
     if (listen_sock == -1) {
-      fprintf(stderr, "Unable to create socket: %s", strerror(errno));
+      fprintf(stderr, "Unable to create socket: %s\n", strerror(errno));
       return 1;
     }
-    int opt = 1;
-    if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1) {
-      fprintf(stderr, "Unable to set reuseaddr on socket: %s", strerror(errno));
+    int reuseaddr = 1;
+    if (setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &reuseaddr, sizeof(reuseaddr)) == -1) {
+      fprintf(stderr, "Unable to set reuseaddr on socket: %s\n", strerror(errno));
       return 1;
     }
     struct sockaddr_in addr = {
@@ -921,17 +921,22 @@ int main(int argc, char **argv)
       .sin_port = htons(rvfi_dii_port)
     };
     if (bind(listen_sock, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
-      fprintf(stderr, "Unable to set bind socket: %s", strerror(errno));
+      fprintf(stderr, "Unable to set bind socket: %s\n", strerror(errno));
       return 1;
     }
     if (listen(listen_sock, 1) == -1) {
-      fprintf(stderr, "Unable to listen on socket: %s", strerror(errno));
+      fprintf(stderr, "Unable to listen on socket: %s\n", strerror(errno));
       return 1;
     }
-    printf("Waiting for connection\n");
+    socklen_t addrlen = sizeof(addr);
+    if (getsockname(listen_sock, (struct sockaddr *) &addr, &addrlen) == -1) {
+        fprintf(stderr, "Unable to getsockname() on socket: %s\n", strerror(errno));
+      return 1;
+    }
+    printf("Waiting for connection on port %d.\n", ntohs(addr.sin_port));
     rvfi_dii_sock = accept(listen_sock, NULL, NULL);
     if (rvfi_dii_sock == -1) {
-      fprintf(stderr, "Unable to accept connection on socket: %s", strerror(errno));
+      fprintf(stderr, "Unable to accept connection on socket: %s\n", strerror(errno));
       return 1;
     }
     close(listen_sock);

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -683,6 +683,7 @@ static void get_and_send_rvfi_packet(packet_reader_fn *reader) {
   lbits packet;
   CREATE(lbits)(&packet);
   reader(&packet, UNIT);
+  /* Note: packet.len is the size in bits, not bytes. */
   if (packet.len % 8 != 0) {
     fprintf(stderr, "RVFI-DII trace packet not byte aligned: %d\n", (int)packet.len);
     exit(1);
@@ -691,6 +692,10 @@ static void get_and_send_rvfi_packet(packet_reader_fn *reader) {
   if (config_print_rvfi) {
     print_bits("packet = ", packet);
     fprintf(stderr, "Sending packet with length %zd... ", send_size);
+  }
+  if (send_size > 4096) {
+    fprintf(stderr, "Unexpected large packet size (> 4KB): %zd\n", send_size);
+    exit(1);
   }
   unsigned char bytes[send_size];
   /* mpz_export might not write all of the null bytes */

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -935,6 +935,20 @@ int main(int argc, char **argv)
       return 1;
     }
     close(listen_sock);
+    // Ensure that the socket is blocking
+    int fd_flags = fcntl(rvfi_dii_sock, F_GETFL);
+    if (fd_flags == -1) {
+      fprintf(stderr, "Failed to get file descriptor flags for socket!\n");
+      return 1;
+    }
+    if (config_print_rvfi) {
+      fprintf(stderr, "RVFI socket fd flags=%d, nonblocking=%d\n", fd_flags,
+              (fd_flags & O_NONBLOCK) != 0);
+    }
+    if (fd_flags & O_NONBLOCK) {
+      fprintf(stderr, "Socket was non-blocking, this will not work!\n");
+      return 1;
+    }
     printf("Connected\n");
   } else
     entry = load_sail(file);

--- a/model/riscv_fetch_rvfi.sail
+++ b/model/riscv_fetch_rvfi.sail
@@ -1,6 +1,7 @@
 function fetch() -> FetchResult = {
   rvfi_inst_data->rvfi_order()    = minstret;
   rvfi_pc_data->rvfi_pc_rdata() = EXTZ(get_arch_pc());
+  rvfi_inst_data->rvfi_mode() = EXTZ(privLevel_to_bits(cur_privilege));
 
   /* First allow extensions to check pc */
   match ext_fetch_check_pc(PC, PC) {

--- a/model/riscv_fetch_rvfi.sail
+++ b/model/riscv_fetch_rvfi.sail
@@ -1,6 +1,6 @@
 function fetch() -> FetchResult = {
-  rvfi_exec->rvfi_order()    = minstret;
-  rvfi_exec->rvfi_pc_rdata() = EXTZ(get_arch_pc());
+  rvfi_inst_data->rvfi_order()    = minstret;
+  rvfi_pc_data->rvfi_pc_rdata() = EXTZ(get_arch_pc());
 
   /* First allow extensions to check pc */
   match ext_fetch_check_pc(PC, PC) {
@@ -13,12 +13,7 @@ function fetch() -> FetchResult = {
         TR_Failure(e, _) => F_Error(e, PC),
         TR_Address(_, _) => {
           let i = rvfi_instruction.rvfi_insn();
-          rvfi_exec->rvfi_insn()     = EXTZ(i);
-          /* TODO: should we write these even if they're not really registers? */
-          rvfi_exec->rvfi_rs1_data() = EXTZ(X(i[19 .. 15]));
-          rvfi_exec->rvfi_rs2_data() = EXTZ(X(i[24 .. 20]));
-          rvfi_exec->rvfi_rs1_addr() = sail_zero_extend(i[19 .. 15],8);
-          rvfi_exec->rvfi_rs2_addr() = sail_zero_extend(i[24 .. 20],8);
+          rvfi_inst_data->rvfi_insn()   = EXTZ(i);
           if   (i[1 .. 0] != 0b11)
           then F_RVC(i[15 .. 0])
           else {

--- a/model/riscv_fetch_rvfi.sail
+++ b/model/riscv_fetch_rvfi.sail
@@ -2,6 +2,7 @@ function fetch() -> FetchResult = {
   rvfi_inst_data->rvfi_order()    = minstret;
   rvfi_pc_data->rvfi_pc_rdata() = EXTZ(get_arch_pc());
   rvfi_inst_data->rvfi_mode() = EXTZ(privLevel_to_bits(cur_privilege));
+  rvfi_inst_data->rvfi_ixl() = EXTZ(misa.MXL());
 
   /* First allow extensions to check pc */
   match ext_fetch_check_pc(PC, PC) {

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -73,18 +73,16 @@ function pmp_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_
 /* Atomic accesses can be done to MMIO regions, e.g. in kernel access to device registers. */
 
 $ifdef RVFI_DII
-val rvfi_read : forall 'n, 'n > 0. (xlenbits, atom('n), MemoryOpResult(bits(8 * 'n))) -> unit effect {wreg}
+val rvfi_read : forall 'n, 'n > 0. (xlenbits, atom('n), MemoryOpResult((bits(8 * 'n), mem_meta))) -> unit effect {wreg}
 function rvfi_read (addr, width, result) = {
   rvfi_mem_data->rvfi_mem_addr() = EXTZ(addr);
   rvfi_mem_data_present = true;
   match result {
     /* TODO: report tag bit for capability writes and extend mask by one bit. */
-    MemValue(v) => if   width <= 8
-                   then { rvfi_mem_data->rvfi_mem_rdata() = sail_zero_extend(v,64);
-                          rvfi_mem_data->rvfi_mem_rmask() = rvfi_encode_width_mask(width) }
-                   else { rvfi_mem_data->rvfi_mem_rdata() = v[63..0]; /* report low bits only */
-                          assert(width == 16, "Should only be used for capabilities");
-                          rvfi_mem_data->rvfi_mem_rmask() = rvfi_encode_width_mask(16)},
+    MemValue(v, _) => if width <= 16
+                       then { rvfi_mem_data->rvfi_mem_rdata() = sail_zero_extend(v, 256);
+                              rvfi_mem_data->rvfi_mem_rmask() = rvfi_encode_width_mask(width) }
+                       else { internal_error("Expected at most 16 bytes here!") },
     MemException(_) => ()
   };
 }
@@ -111,7 +109,7 @@ function mem_read_meta (typ, paddr, width, aq, rl, res, meta) = {
       (false, true,  true)  => throw(Error_not_implemented("lr.rl")),
       (_, _, _)             => pmp_mem_read(typ, paddr, width, aq, rl, res, meta)
     };
-  rvfi_read(paddr, width, MemoryOpResult_drop_meta(result));
+  rvfi_read(paddr, width, result);
   result
 }
 
@@ -136,18 +134,16 @@ function mem_write_ea (addr, width, aq, rl, con) = {
 }
 
 $ifdef RVFI_DII
-val rvfi_write : forall 'n, 0 < 'n <= max_mem_access . (xlenbits, atom('n), bits(8 * 'n)) -> unit effect {wreg}
-function rvfi_write (addr, width, value) = {
+val rvfi_write : forall 'n, 0 < 'n <= max_mem_access . (xlenbits, atom('n), bits(8 * 'n), mem_meta) -> unit effect {wreg}
+function rvfi_write (addr, width, value, meta) = {
   rvfi_mem_data->rvfi_mem_addr() = EXTZ(addr);
   rvfi_mem_data_present = true;
-  if width <= 8 then {
-    rvfi_mem_data->rvfi_mem_wdata() = sail_zero_extend(value,64);
+  /* TODO: report tag bit for capability writes and extend mask by one bit. */
+  if width <= 16 then {
+    rvfi_mem_data->rvfi_mem_wdata() = sail_zero_extend(value,256);
     rvfi_mem_data->rvfi_mem_wmask() = rvfi_encode_width_mask(width);
   } else {
-    /* TODO: report tag bit for capability writes and extend mask by one bit. */
-    rvfi_mem_data->rvfi_mem_wdata() = value[63..0];
-    assert(width == 16, "Should only be used for capabilities");
-    rvfi_mem_data->rvfi_mem_wmask() = rvfi_encode_width_mask(width);
+    internal_error("Expected at most 16 bytes here!");
   }
 }
 $else
@@ -157,7 +153,7 @@ $endif
 
 // only used for actual memory regions, to avoid MMIO effects
 function phys_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk : write_kind, paddr : xlenbits, width : atom('n), data : bits(8 * 'n), meta : mem_meta) -> MemoryOpResult(bool) = {
-  rvfi_write(paddr, width, data);
+  rvfi_write(paddr, width, data, meta);
   let result = MemValue(write_ram(wk, paddr, width, data, meta));
   if   get_config_print_mem()
   then print_mem("mem[" ^ BitStr(paddr) ^ "] <- " ^ BitStr(data));
@@ -193,7 +189,7 @@ function pmp_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk: write_kind, pa
  */
 val mem_write_value_meta : forall 'n, 0 < 'n <= max_mem_access . (xlenbits, atom('n), bits(8 * 'n), ext_access_type, mem_meta, bool, bool, bool) -> MemoryOpResult(bool) effect {wmv, wmvt, rreg, wreg, escape}
 function mem_write_value_meta (paddr, width, value, ext_acc, meta, aq, rl, con) = {
-  rvfi_write(paddr, width, value);
+  rvfi_write(paddr, width, value, meta);
   if (rl | con) & (~ (is_aligned_addr(paddr, width)))
   then MemException(E_SAMO_Addr_Align())
   else match (aq, rl, con) {

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -75,13 +75,16 @@ function pmp_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_
 $ifdef RVFI_DII
 val rvfi_read : forall 'n, 'n > 0. (xlenbits, atom('n), MemoryOpResult(bits(8 * 'n))) -> unit effect {wreg}
 function rvfi_read (addr, width, result) = {
-  rvfi_exec->rvfi_mem_addr() = EXTZ(addr);
+  rvfi_mem_data->rvfi_mem_addr() = EXTZ(addr);
+  rvfi_mem_data_present = true;
   match result {
+    /* TODO: report tag bit for capability writes and extend mask by one bit. */
     MemValue(v) => if   width <= 8
-                   then { rvfi_exec->rvfi_mem_rdata() = sail_zero_extend(v,64);
-                          rvfi_exec->rvfi_mem_rmask() = rvfi_encode_width_mask(width) }
-                   else { rvfi_exec->rvfi_mem_rdata() = v[63..0];
-                          rvfi_exec->rvfi_mem_rmask() = 0xFF},
+                   then { rvfi_mem_data->rvfi_mem_rdata() = sail_zero_extend(v,64);
+                          rvfi_mem_data->rvfi_mem_rmask() = rvfi_encode_width_mask(width) }
+                   else { rvfi_mem_data->rvfi_mem_rdata() = v[63..0]; /* report low bits only */
+                          assert(width == 16, "Should only be used for capabilities");
+                          rvfi_mem_data->rvfi_mem_rmask() = rvfi_encode_width_mask(16)},
     MemException(_) => ()
   };
 }
@@ -135,13 +138,16 @@ function mem_write_ea (addr, width, aq, rl, con) = {
 $ifdef RVFI_DII
 val rvfi_write : forall 'n, 0 < 'n <= max_mem_access . (xlenbits, atom('n), bits(8 * 'n)) -> unit effect {wreg}
 function rvfi_write (addr, width, value) = {
-  rvfi_exec->rvfi_mem_addr() = EXTZ(addr);
+  rvfi_mem_data->rvfi_mem_addr() = EXTZ(addr);
+  rvfi_mem_data_present = true;
   if width <= 8 then {
-    rvfi_exec->rvfi_mem_wdata() = sail_zero_extend(value,64);
-    rvfi_exec->rvfi_mem_wmask() = rvfi_encode_width_mask(width);
+    rvfi_mem_data->rvfi_mem_wdata() = sail_zero_extend(value,64);
+    rvfi_mem_data->rvfi_mem_wmask() = rvfi_encode_width_mask(width);
   } else {
-    rvfi_exec->rvfi_mem_wdata() = value[63..0];
-    rvfi_exec->rvfi_mem_wmask() = 0xFF;
+    /* TODO: report tag bit for capability writes and extend mask by one bit. */
+    rvfi_mem_data->rvfi_mem_wdata() = value[63..0];
+    assert(width == 16, "Should only be used for capabilities");
+    rvfi_mem_data->rvfi_mem_wmask() = rvfi_encode_width_mask(width);
   }
 }
 $else

--- a/model/riscv_regs.sail
+++ b/model/riscv_regs.sail
@@ -84,8 +84,9 @@ function rX r = {
 $ifdef RVFI_DII
 val rvfi_wX : forall 'n, 0 <= 'n < 32. (regno('n), xlenbits) -> unit effect {wreg}
 function rvfi_wX (r,v) = {
-  rvfi_exec->rvfi_rd_wdata() = EXTZ(v);
-  rvfi_exec->rvfi_rd_addr() = to_bits(8,r);
+  rvfi_int_data->rvfi_rd_wdata() = EXTZ(v);
+  rvfi_int_data->rvfi_rd_addr() = to_bits(8,r);
+  rvfi_int_data_present = true;
 }
 $else
 val rvfi_wX : forall 'n, 0 <= 'n < 32. (regno('n), xlenbits) -> unit

--- a/model/riscv_step_rvfi.sail
+++ b/model/riscv_step_rvfi.sail
@@ -6,7 +6,7 @@ function ext_pre_step_hook()  -> unit = ()
 
 function ext_post_step_hook() -> unit = {
   /* record the next pc */
-  rvfi_exec->rvfi_pc_wdata() = EXTZ(get_arch_pc())
+  rvfi_pc_data->rvfi_pc_wdata() = EXTZ(get_arch_pc())
 }
 
 val ext_init : unit -> unit effect {wreg}
@@ -14,12 +14,7 @@ function ext_init() = {
   init_base_regs();
   init_fdext_regs();
   /* these are here so that the C backend doesn't prune them out. */
-  rvfi_set_instr_packet(0x0000000000000000);
-  print_bits("", rvfi_get_cmd());
   // let _ = rvfi_step(0);
-  rvfi_zero_exec_packet();
-  rvfi_halt_exec_packet();
-  let _ = rvfi_get_exec_packet();
   ext_rvfi_init();
   ()
 }

--- a/model/riscv_sys_control.sail
+++ b/model/riscv_sys_control.sail
@@ -285,8 +285,9 @@ function tval(excinfo : option(xlenbits)) -> xlenbits = {
 
 $ifdef RVFI_DII
 val rvfi_trap : unit -> unit effect {wreg}
+// TODO: record rvfi_trap_data
 function rvfi_trap () =
-  rvfi_exec->rvfi_trap() = 0x01
+  rvfi_inst_data->rvfi_trap() = 0x01
 $else
 val rvfi_trap : unit -> unit
 function rvfi_trap () = ()

--- a/model/rvfi_dii.sail
+++ b/model/rvfi_dii.sail
@@ -33,8 +33,8 @@ val print_instr_packet : bits(64) -> unit
 
 function print_instr_packet(bs) = {
   let p = Mk_RVFI_DII_Instruction_Packet(bs);
-  print_bits("command", p.rvfi_cmd());
-  print_bits("instruction", p.rvfi_insn())
+  print_bits("command ", p.rvfi_cmd());
+  print_bits("instruction ", p.rvfi_insn())
 }
 
 bitfield RVFI_DII_Execution_Packet_V1 : bits(704) = {
@@ -255,7 +255,7 @@ val rvfi_get_exec_packet_v2 : unit -> bits(448 + 256 + 256) effect {rreg}
 
 function rvfi_get_exec_packet_v2 () = {
   // TODO: add the other data
-  // TODO: find a way to return a variable-legnth bitvector
+  // TODO: find a way to return a variable-length bitvector
   let packet = Mk_RVFI_DII_Execution_PacketV2(EXTZ(0b0));
   let packet = update_trace_version(packet, EXTZ(0x2));
   let packet = update_basic_data(packet, rvfi_inst_data.bits());

--- a/model/rvfi_dii.sail
+++ b/model/rvfi_dii.sail
@@ -219,6 +219,7 @@ function rvfi_get_exec_packet_v1 () = {
   let v1_packet = Mk_RVFI_DII_Execution_Packet_V1(EXTZ(0b0));
   // Convert the v2 packet to a v1 packet
   let v1_packet = update_rvfi_intr(v1_packet, rvfi_inst_data.rvfi_intr());
+  let v1_packet = update_rvfi_halt(v1_packet, rvfi_inst_data.rvfi_halt());
   let v1_packet = update_rvfi_trap(v1_packet, rvfi_inst_data.rvfi_trap());
   let v1_packet = update_rvfi_insn(v1_packet, rvfi_inst_data.rvfi_insn());
   let v1_packet = update_rvfi_order(v1_packet, rvfi_inst_data.rvfi_order());

--- a/model/rvfi_dii.sail
+++ b/model/rvfi_dii.sail
@@ -206,13 +206,14 @@ function rvfi_zero_exec_packet () = {
   rvfi_mem_data_present = false;
 }
 
+// FIXME: most of these will no longer be necessary once we use the c2 sail backend.
+
 val rvfi_halt_exec_packet : unit -> unit effect {wreg}
 
 function rvfi_halt_exec_packet () =
   rvfi_inst_data->rvfi_halt() = 0x01
 
 val rvfi_get_v2_support_packet : unit -> bits(704)
-
 function rvfi_get_v2_support_packet () = {
   let rvfi_exec = Mk_RVFI_DII_Execution_Packet_V1(EXTZ(0b0));
   // Returning 0x3 (using the unused high bits) in halt instead of 0x1 means
@@ -224,7 +225,6 @@ function rvfi_get_v2_support_packet () = {
 }
 
 val rvfi_get_exec_packet_v1 : unit -> bits(704) effect {rreg}
-
 function rvfi_get_exec_packet_v1 () = {
   let v1_packet = Mk_RVFI_DII_Execution_Packet_V1(EXTZ(0b0));
   // Convert the v2 packet to a v1 packet
@@ -254,7 +254,6 @@ function rvfi_get_exec_packet_v1 () = {
 }
 
 val rvfi_get_v2_trace_size : unit -> bits(64) effect {rreg}
-
 function rvfi_get_v2_trace_size () = {
   let trace_size : bits(64) = to_bits(64, 512);
   let trace_size = if (rvfi_int_data_present) then trace_size + 320 else trace_size;
@@ -262,8 +261,7 @@ function rvfi_get_v2_trace_size () = {
   return trace_size >> 3; // we have to return bytes not bits
 }
 
-val rvfi_get_exec_packet_v2 : unit -> bits(512 + 320 + 704) effect {rreg}
-
+val rvfi_get_exec_packet_v2 : unit -> bits(512) effect {rreg}
 function rvfi_get_exec_packet_v2 () = {
   // TODO: add the other data
   // TODO: find a way to return a variable-length bitvector
@@ -277,7 +275,19 @@ function rvfi_get_exec_packet_v2 () = {
   // we always return a max-size packet from this function, and the C emulator
   // ensures that only trace_size bits are sent over the socket.
   let packet = update_trace_size(packet, rvfi_get_v2_trace_size());
-  return rvfi_mem_data.bits() @ rvfi_int_data.bits() @ packet.bits();
+  return packet.bits();
+}
+
+val rvfi_get_int_data : unit -> bits(320) effect {rreg}
+function rvfi_get_int_data () = {
+  assert(rvfi_int_data_present, "reading uninitialized data");
+  return rvfi_int_data.bits();
+}
+
+val rvfi_get_mem_data : unit -> bits(704) effect {rreg}
+function rvfi_get_mem_data () = {
+  assert(rvfi_mem_data_present, "reading uninitialized data");
+  return rvfi_mem_data.bits();
 }
 
 val rvfi_encode_width_mask : forall 'n, 0 < 'n <= 32. atom('n) -> bits(32)

--- a/model/rvfi_dii.sail
+++ b/model/rvfi_dii.sail
@@ -119,64 +119,68 @@ bitfield RVFI_DII_Execution_Packet_PC : bits(128) = {
   rvfi_pc_wdata  : 127 ..  64,
 }
 
-bitfield RVFI_DII_Execution_Packet_Ext_Integer : bits(256) = {
+bitfield RVFI_DII_Execution_Packet_Ext_Integer : bits(320) = {
+  magic : 63 .. 0, // must be "int-data"
   /// rvfi_rd_wdata is the value of the x register addressed by rd after
   /// execution of this instruction. This output must be zero when rd is zero.
-  rvfi_rd_wdata  : 63 .. 0,
+  rvfi_rd_wdata  : 127 ..  64,
   /// rvfi_rs1_rdata/rvfi_rs2_rdata is the value of the x register addressed
   /// by rs1/rs2 before execution of this instruction. This output must be
   /// zero when rs1/rs2 is zero.
-  rvfi_rs1_rdata  : 127 ..  64,
-  rvfi_rs2_rdata  : 191 .. 128,
+  rvfi_rs1_rdata  : 191 .. 128,
+  rvfi_rs2_rdata  : 255 .. 192,
   /// rvfi_rd_addr is the decoded rd register address for the retired
   /// instruction. For an instruction that writes no rd register, this output
   /// must always be zero.
-  rvfi_rd_addr      : 199 .. 192,
+  rvfi_rd_addr      : 263 .. 256,
   /// rvfi_rs1_addr and rvfi_rs2_addr are the decoded rs1 and rs1 register
   /// addresses for the retired instruction. For an instruction that reads no
   /// rs1/rs2 register, this output can have an arbitrary value. However, if
   /// this output is nonzero then rvfi_rs1_rdata must carry the value stored
   /// in that register in the pre-state.
-  rvfi_rs1_addr  : 207 .. 200,
-  rvfi_rs2_addr  : 215 .. 208,
-  padding  : 255 .. 216,
+  rvfi_rs1_addr  : 271 .. 264,
+  rvfi_rs2_addr  : 279 .. 272,
+  padding  : 319 .. 280,
 }
 
-bitfield RVFI_DII_Execution_Packet_Ext_MemAccess : bits(256) = {
-  //// For memory operations (rvfi_mem_rmask and/or rvfi_mem_wmask are
-  ///non-zero), rvfi_mem_addr holds the accessed memory location.
-  rvfi_mem_addr  : 63 .. 0,
+bitfield RVFI_DII_Execution_Packet_Ext_MemAccess : bits(704) = {
+  magic : 63 .. 0, // must be "mem-data"
   /// rvfi_mem_rdata is the pre-state data read from rvfi_mem_addr.
   /// rvfi_mem_rmask specifies which bytes are valid.
-  rvfi_mem_rdata  : 127 ..  64,
+  /// CHERI-extension: widened to 32 bytes to allow reporting 129 bits
+  rvfi_mem_rdata : 319 ..  64,
   /// rvfi_mem_wdata is the post-state data written to rvfi_mem_addr.
   /// rvfi_mem_wmask specifies which bytes are valid.
-  rvfi_mem_wdata  : 191 .. 128,
-  // Note: we extend rmask+wmask to 32 bits to allow reporting the mask for
-  // CHERI/RV128 accesses here, even though the actual data needs to be
-  // returned in a separate struct.
+  /// CHERI-extension: widened to 32 bytes to allow reporting 129 bits
+  rvfi_mem_wdata : 575 .. 320,
   /// rvfi_mem_rmask is a bitmask that specifies which bytes in rvfi_mem_rdata
   /// contain valid read data from rvfi_mem_addr.
-  rvfi_mem_rmask      : 223 .. 192,
+  /// CHERI-extension: we extend rmask+wmask to 32 bits to allow reporting the
+  /// mask for CHERI/RV128 accesses here.
+  rvfi_mem_rmask      : 607 .. 576,
   /// rvfi_mem_wmask is a bitmask that specifies which bytes in rvfi_mem_wdata
   /// contain valid data that is written to rvfi_mem_addr.
-  rvfi_mem_wmask      : 255 .. 224,
+  /// CHERI-extension: widened to 32 bits
+  rvfi_mem_wmask      : 639 .. 608,
+  /// For memory operations (rvfi_mem_rmask and/or rvfi_mem_wmask are
+  /// non-zero), rvfi_mem_addr holds the accessed memory location.
+  rvfi_mem_addr : 703 .. 640,
 }
 
-bitfield RVFI_DII_Execution_PacketV2 : bits(448) = {
-  trace_version : 31 .. 0, // must be set to 2
-  trace_size : 63 .. 32, // total size of the trace packet + extensions
-  basic_data : 255 .. 64, // RVFI_DII_Execution_Packet_InstMetaData
-  pc_data : 383 .. 256, // RVFI_DII_Execution_Packet_PC
-  // available_fields : 447 .. 383,
-  integer_data_available: 384, // Followed by RVFI_DII_Execution_Packet_Ext_Integer if set
-  memory_access_data_available: 385, // Followed by RVFI_DII_Execution_Packet_Ext_MemAccess if set
-  floating_point_data_available: 386, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_FP if set
-  csr_read_write_data_available: 387, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_CSR if set
-  cheri_data_available: 388, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_CHERI if set
-  cheri_scr_read_write_data_available: 389, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_CHERI_SCR if set
-  trap_data_available: 389, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_Trap if set
-  unused_data_available_fields : 447 .. 390, // To be used for additional RVFI_DII_Execution_Packet_Ext_* structs
+bitfield RVFI_DII_Execution_PacketV2 : bits(512) = {
+  magic : 63 .. 0,         // must be set to 'trace-v2'
+  trace_size : 127 .. 64,  // total size of the trace packet + extensions
+  basic_data : 319 .. 128, // RVFI_DII_Execution_Packet_InstMetaData
+  pc_data : 447 .. 320,    // RVFI_DII_Execution_Packet_PC
+  // available_fields : 511 .. 448,
+  integer_data_available: 448, // Followed by RVFI_DII_Execution_Packet_Ext_Integer if set
+  memory_access_data_available: 449, // Followed by R VFI_DII_Execution_Packet_Ext_MemAccess if set
+  floating_point_data_available: 450, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_FP if set
+  csr_read_write_data_available: 451, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_CSR if set
+  cheri_data_available: 452, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_CHERI if set
+  cheri_scr_read_write_data_available: 453, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_CHERI_SCR if set
+  trap_data_available: 454, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_Trap if set
+  unused_data_available_fields : 511 .. 455, // To be used for additional RVFI_DII_Execution_Packet_Ext_* structs
 }
 
 register rvfi_inst_data : RVFI_DII_Execution_Packet_InstMetaData
@@ -192,9 +196,13 @@ val rvfi_zero_exec_packet : unit -> unit effect {wreg}
 function rvfi_zero_exec_packet () = {
   rvfi_inst_data = Mk_RVFI_DII_Execution_Packet_InstMetaData(EXTZ(0b0));
   rvfi_pc_data = Mk_RVFI_DII_Execution_Packet_PC(EXTZ(0b0));
-  rvfi_int_data = Mk_RVFI_DII_Execution_Packet_Ext_Integer(EXTZ(0b0));
+  rvfi_int_data = Mk_RVFI_DII_Execution_Packet_Ext_Integer(EXTZ(0x0));
+  // magic = "int-data" -> 0x617461642d746e69 (big-endian)
+  rvfi_int_data = update_magic(rvfi_int_data, 0x617461642d746e69);
   rvfi_int_data_present = false;
-  rvfi_mem_data = Mk_RVFI_DII_Execution_Packet_Ext_MemAccess(EXTZ(0b0));
+  rvfi_mem_data = Mk_RVFI_DII_Execution_Packet_Ext_MemAccess(EXTZ(0x0));
+  // magic = "mem-data" -> 0x617461642d6d656d (big-endian)
+  rvfi_mem_data = update_magic(rvfi_mem_data, 0x617461642d6d656d);
   rvfi_mem_data_present = false;
 }
 
@@ -207,8 +215,10 @@ val rvfi_get_v2_support_packet : unit -> bits(704)
 
 function rvfi_get_v2_support_packet () = {
   let rvfi_exec = Mk_RVFI_DII_Execution_Packet_V1(EXTZ(0b0));
-  // Returning 0x3 in halt instead of 0x1 means that we support the version 2
-  // wire format.
+  // Returning 0x3 (using the unused high bits) in halt instead of 0x1 means
+  // that we support the version 2 wire format. This is required to keep
+  // backwards compatibility with old implementations that do not support
+  // the new trace format.
   let rvfi_exec = update_rvfi_halt(rvfi_exec, 0x03);
   return rvfi_exec.bits();
 }
@@ -236,29 +246,29 @@ function rvfi_get_exec_packet_v1 () = {
 
   let v1_packet = update_rvfi_mem_wmask(v1_packet, truncate(rvfi_mem_data.rvfi_mem_wmask(), 8));
   let v1_packet = update_rvfi_mem_rmask(v1_packet, truncate(rvfi_mem_data.rvfi_mem_rmask(), 8));
-  let v1_packet = update_rvfi_mem_wdata(v1_packet, rvfi_mem_data.rvfi_mem_wdata());
-  let v1_packet = update_rvfi_mem_rdata(v1_packet, rvfi_mem_data.rvfi_mem_rdata());
+  let v1_packet = update_rvfi_mem_wdata(v1_packet, truncate(rvfi_mem_data.rvfi_mem_wdata(), 64));
+  let v1_packet = update_rvfi_mem_rdata(v1_packet, truncate(rvfi_mem_data.rvfi_mem_rdata(), 64));
   let v1_packet = update_rvfi_mem_addr(v1_packet, rvfi_mem_data.rvfi_mem_addr());
 
   return v1_packet.bits();
 }
 
-val rvfi_get_v2_trace_size : unit -> bits(32) effect {rreg}
+val rvfi_get_v2_trace_size : unit -> bits(64) effect {rreg}
 
 function rvfi_get_v2_trace_size () = {
-  let trace_size = 448;
-  let trace_size = if (rvfi_int_data_present) then trace_size + 256 else trace_size;
-  let trace_size = if (rvfi_mem_data_present) then trace_size + 256 else trace_size;
-  return to_bits(32, trace_size);
+  let trace_size : bits(64) = to_bits(64, 512);
+  let trace_size = if (rvfi_int_data_present) then trace_size + 320 else trace_size;
+  let trace_size = if (rvfi_mem_data_present) then trace_size + 704 else trace_size;
+  return trace_size >> 3; // we have to return bytes not bits
 }
 
-val rvfi_get_exec_packet_v2 : unit -> bits(448 + 256 + 256) effect {rreg}
+val rvfi_get_exec_packet_v2 : unit -> bits(512 + 320 + 704) effect {rreg}
 
 function rvfi_get_exec_packet_v2 () = {
   // TODO: add the other data
   // TODO: find a way to return a variable-length bitvector
   let packet = Mk_RVFI_DII_Execution_PacketV2(EXTZ(0b0));
-  let packet = update_trace_version(packet, EXTZ(0x2));
+  let packet = update_magic(packet, 0x32762d6563617274); // ASCII "trace-v2" (BE)
   let packet = update_basic_data(packet, rvfi_inst_data.bits());
   let packet = update_pc_data(packet, rvfi_pc_data.bits());
   let packet = update_integer_data_available(packet, bool_to_bits(rvfi_int_data_present));
@@ -267,7 +277,7 @@ function rvfi_get_exec_packet_v2 () = {
   // we always return a max-size packet from this function, and the C emulator
   // ensures that only trace_size bits are sent over the socket.
   let packet = update_trace_size(packet, rvfi_get_v2_trace_size());
-  return packet.bits() @ rvfi_int_data.bits() @ rvfi_mem_data.bits();
+  return rvfi_mem_data.bits() @ rvfi_int_data.bits() @ packet.bits();
 }
 
 val rvfi_encode_width_mask : forall 'n, 0 < 'n <= 32. atom('n) -> bits(32)

--- a/model/rvfi_dii.sail
+++ b/model/rvfi_dii.sail
@@ -25,6 +25,10 @@ val rvfi_get_cmd : unit -> bits(8) effect {rreg}
 
 function rvfi_get_cmd () = rvfi_instruction.rvfi_cmd()
 
+val rvfi_get_insn : unit -> bits(32) effect {rreg}
+
+function rvfi_get_insn () = rvfi_instruction.rvfi_insn()
+
 val print_instr_packet : bits(64) -> unit
 
 function print_instr_packet(bs) = {
@@ -33,7 +37,7 @@ function print_instr_packet(bs) = {
   print_bits("instruction", p.rvfi_insn())
 }
 
-bitfield RVFI_DII_Execution_Packet : bits(704) = {
+bitfield RVFI_DII_Execution_Packet_V1 : bits(704) = {
    rvfi_intr      : 703 .. 696, // [87] Trap handler:            Set for first instruction in trap handler.
    rvfi_halt      : 695 .. 688, // [86] Halt indicator:          Marks the last instruction retired 
                                 //                                      before halting execution.
@@ -58,46 +62,237 @@ bitfield RVFI_DII_Execution_Packet : bits(704) = {
    rvfi_order     :  63 ..   0, // [00 - 07] Instruction number:      INSTRET value after completion.
 }
 
-register rvfi_exec : RVFI_DII_Execution_Packet
+bitfield RVFI_DII_Execution_Packet_InstMetaData : bits(192) = {
+  /// The rvfi_order field must be set to the instruction index. No indices
+  /// must be used twice and there must be no gaps. Instructions may be
+  /// retired in a reordered fashion, as long as causality is preserved
+  /// (register and memory write operations must be retired before the read
+  /// operations that depend on them).
+  rvfi_order  : 63 .. 0,
+  /// rvfi_insn is the instruction word for the retired instruction. In case
+  /// of an instruction with fewer than ILEN bits, the upper bits of this
+  /// output must be all zero. For compressed instructions the compressed
+  /// instruction word must be output on this port. For fused instructions the
+  /// complete fused instruction sequence must be output.
+  rvfi_insn  : 127 ..  64,
+  /// rvfi_trap must be set for an instruction that cannot be decoded as a
+  /// legal instruction, such as 0x00000000.
+  /// In addition, rvfi_trap must be set for a misaligned memory read or
+  /// write in PMAs that don't allow misaligned access, or other memory
+  /// access violations. rvfi_trap must also be set for a jump instruction
+  /// that jumps to a misaligned instruction.
+  rvfi_trap  : 135 ..  128,
+  /// The signal rvfi_halt must be set when the instruction is the last
+  /// instruction that the core retires before halting execution. It should not
+  /// be set for an instruction that triggers a trap condition if the CPU
+  /// reacts to the trap by executing a trap handler. This signal enables
+  /// verification of liveness properties.
+  rvfi_halt  : 143 ..  136,
+  /// rvfi_intr must be set for the first instruction that is part of a trap
+  /// handler, i.e. an instruction that has a rvfi_pc_rdata that does not
+  /// match the rvfi_pc_wdata of the previous instruction.
+  rvfi_intr  : 151 ..  144,
+  /// rvfi_mode must be set to the current privilege level, using the following
+  /// encoding: 0=U-Mode, 1=S-Mode, 2=Reserved, 3=M-Mode
+  rvfi_mode  : 159 ..  152,
+  /// rvfi_ixl must be set to the value of MXL/SXL/UXL in the current privilege level,
+  /// using the following encoding: 1=32, 2=64
+  rvfi_ixl  : 167 ..  160,
 
+  /// When the core retires an instruction, it asserts the rvfi_valid signal
+  /// and uses the signals described below to output the details of the
+  /// retired instruction. The signals below are only valid during such a
+  /// cycle and can be driven to arbitrary values in a cycle in which
+  /// rvfi_valid is not asserted.
+  rvfi_valid  : 175 ..  168,
+  // Note: since we only send these packets in the valid state, we could
+  // omit the valid signal, but we need 3 bytes of padding after ixl anyway
+  // so we might as well include it
+  padding  : 191 ..  176,
+}
+
+bitfield RVFI_DII_Execution_Packet_PC : bits(128) = {
+  /// This is the program counter (pc) before (rvfi_pc_rdata) and after
+  /// (rvfi_pc_wdata) execution of this instruction. I.e. this is the address
+  /// of the retired instruction and the address of the next instruction.
+  rvfi_pc_rdata  : 63 .. 0,
+  rvfi_pc_wdata  : 127 ..  64,
+}
+
+bitfield RVFI_DII_Execution_Packet_Ext_Integer : bits(256) = {
+  /// rvfi_rd_wdata is the value of the x register addressed by rd after
+  /// execution of this instruction. This output must be zero when rd is zero.
+  rvfi_rd_wdata  : 63 .. 0,
+  /// rvfi_rs1_rdata/rvfi_rs2_rdata is the value of the x register addressed
+  /// by rs1/rs2 before execution of this instruction. This output must be
+  /// zero when rs1/rs2 is zero.
+  rvfi_rs1_rdata  : 127 ..  64,
+  rvfi_rs2_rdata  : 191 .. 128,
+  /// rvfi_rd_addr is the decoded rd register address for the retired
+  /// instruction. For an instruction that writes no rd register, this output
+  /// must always be zero.
+  rvfi_rd_addr      : 199 .. 192,
+  /// rvfi_rs1_addr and rvfi_rs2_addr are the decoded rs1 and rs1 register
+  /// addresses for the retired instruction. For an instruction that reads no
+  /// rs1/rs2 register, this output can have an arbitrary value. However, if
+  /// this output is nonzero then rvfi_rs1_rdata must carry the value stored
+  /// in that register in the pre-state.
+  rvfi_rs1_addr  : 207 .. 200,
+  rvfi_rs2_addr  : 215 .. 208,
+  padding  : 255 .. 216,
+}
+
+bitfield RVFI_DII_Execution_Packet_Ext_MemAccess : bits(256) = {
+  //// For memory operations (rvfi_mem_rmask and/or rvfi_mem_wmask are
+  ///non-zero), rvfi_mem_addr holds the accessed memory location.
+  rvfi_mem_addr  : 63 .. 0,
+  /// rvfi_mem_rdata is the pre-state data read from rvfi_mem_addr.
+  /// rvfi_mem_rmask specifies which bytes are valid.
+  rvfi_mem_rdata  : 127 ..  64,
+  /// rvfi_mem_wdata is the post-state data written to rvfi_mem_addr.
+  /// rvfi_mem_wmask specifies which bytes are valid.
+  rvfi_mem_wdata  : 191 .. 128,
+  // Note: we extend rmask+wmask to 32 bits to allow reporting the mask for
+  // CHERI/RV128 accesses here, even though the actual data needs to be
+  // returned in a separate struct.
+  /// rvfi_mem_rmask is a bitmask that specifies which bytes in rvfi_mem_rdata
+  /// contain valid read data from rvfi_mem_addr.
+  rvfi_mem_rmask      : 223 .. 192,
+  /// rvfi_mem_wmask is a bitmask that specifies which bytes in rvfi_mem_wdata
+  /// contain valid data that is written to rvfi_mem_addr.
+  rvfi_mem_wmask      : 255 .. 224,
+}
+
+bitfield RVFI_DII_Execution_PacketV2 : bits(448) = {
+  trace_version : 31 .. 0, // must be set to 2
+  trace_size : 63 .. 32, // total size of the trace packet + extensions
+  basic_data : 255 .. 64, // RVFI_DII_Execution_Packet_InstMetaData
+  pc_data : 383 .. 256, // RVFI_DII_Execution_Packet_PC
+  // available_fields : 447 .. 383,
+  integer_data_available: 384, // Followed by RVFI_DII_Execution_Packet_Ext_Integer if set
+  memory_access_data_available: 385, // Followed by RVFI_DII_Execution_Packet_Ext_MemAccess if set
+  floating_point_data_available: 386, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_FP if set
+  csr_read_write_data_available: 387, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_CSR if set
+  cheri_data_available: 388, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_CHERI if set
+  cheri_scr_read_write_data_available: 389, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_CHERI_SCR if set
+  trap_data_available: 389, // TODO: Followed by RVFI_DII_Execution_Packet_Ext_Trap if set
+  unused_data_available_fields : 447 .. 390, // To be used for additional RVFI_DII_Execution_Packet_Ext_* structs
+}
+
+register rvfi_inst_data : RVFI_DII_Execution_Packet_InstMetaData
+register rvfi_pc_data : RVFI_DII_Execution_Packet_PC
+register rvfi_int_data : RVFI_DII_Execution_Packet_Ext_Integer
+register rvfi_int_data_present : bool
+register rvfi_mem_data : RVFI_DII_Execution_Packet_Ext_MemAccess
+register rvfi_mem_data_present : bool
+
+// Reset the trace
 val rvfi_zero_exec_packet : unit -> unit effect {wreg}
 
-function rvfi_zero_exec_packet () =
-  rvfi_exec = Mk_RVFI_DII_Execution_Packet(sail_zero_extend(0b0,704))
+function rvfi_zero_exec_packet () = {
+  rvfi_inst_data = Mk_RVFI_DII_Execution_Packet_InstMetaData(EXTZ(0b0));
+  rvfi_pc_data = Mk_RVFI_DII_Execution_Packet_PC(EXTZ(0b0));
+  rvfi_int_data = Mk_RVFI_DII_Execution_Packet_Ext_Integer(EXTZ(0b0));
+  rvfi_int_data_present = false;
+  rvfi_mem_data = Mk_RVFI_DII_Execution_Packet_Ext_MemAccess(EXTZ(0b0));
+  rvfi_mem_data_present = false;
+}
 
 val rvfi_halt_exec_packet : unit -> unit effect {wreg}
 
 function rvfi_halt_exec_packet () =
-  rvfi_exec->rvfi_halt() = 0x01
+  rvfi_inst_data->rvfi_halt() = 0x01
 
-val rvfi_get_exec_packet : unit -> bits(704) effect {rreg}
+val rvfi_get_v2_support_packet : unit -> bits(704)
 
-function rvfi_get_exec_packet() = rvfi_exec.bits()
+function rvfi_get_v2_support_packet () = {
+  let rvfi_exec = Mk_RVFI_DII_Execution_Packet_V1(EXTZ(0b0));
+  // Returning 0x3 in halt instead of 0x1 means that we support the version 2
+  // wire format.
+  let rvfi_exec = update_rvfi_halt(rvfi_exec, 0x03);
+  return rvfi_exec.bits();
+}
 
-val rvfi_encode_width_mask : forall 'n, 0 < 'n <= 8. atom('n) -> bits(8)
+val rvfi_get_exec_packet_v1 : unit -> bits(704) effect {rreg}
+
+function rvfi_get_exec_packet_v1 () = {
+  let v1_packet = Mk_RVFI_DII_Execution_Packet_V1(EXTZ(0b0));
+  // Convert the v2 packet to a v1 packet
+  let v1_packet = update_rvfi_intr(v1_packet, rvfi_inst_data.rvfi_intr());
+  let v1_packet = update_rvfi_trap(v1_packet, rvfi_inst_data.rvfi_trap());
+  let v1_packet = update_rvfi_insn(v1_packet, rvfi_inst_data.rvfi_insn());
+  let v1_packet = update_rvfi_order(v1_packet, rvfi_inst_data.rvfi_order());
+
+  let v1_packet = update_rvfi_pc_wdata(v1_packet, rvfi_pc_data.rvfi_pc_wdata());
+  let v1_packet = update_rvfi_pc_rdata(v1_packet, rvfi_pc_data.rvfi_pc_rdata());
+
+  let v1_packet = update_rvfi_rd_addr(v1_packet, rvfi_int_data.rvfi_rd_addr());
+  let v1_packet = update_rvfi_rs2_addr(v1_packet, rvfi_int_data.rvfi_rs2_addr());
+  let v1_packet = update_rvfi_rs1_addr(v1_packet, rvfi_int_data.rvfi_rs1_addr());
+  let v1_packet = update_rvfi_rd_wdata(v1_packet, rvfi_int_data.rvfi_rd_wdata());
+  let v1_packet = update_rvfi_rs2_data(v1_packet, rvfi_int_data.rvfi_rs2_rdata());
+  let v1_packet = update_rvfi_rs1_data(v1_packet, rvfi_int_data.rvfi_rs1_rdata());
+
+  let v1_packet = update_rvfi_mem_wmask(v1_packet, truncate(rvfi_mem_data.rvfi_mem_wmask(), 8));
+  let v1_packet = update_rvfi_mem_rmask(v1_packet, truncate(rvfi_mem_data.rvfi_mem_rmask(), 8));
+  let v1_packet = update_rvfi_mem_wdata(v1_packet, rvfi_mem_data.rvfi_mem_wdata());
+  let v1_packet = update_rvfi_mem_rdata(v1_packet, rvfi_mem_data.rvfi_mem_rdata());
+  let v1_packet = update_rvfi_mem_addr(v1_packet, rvfi_mem_data.rvfi_mem_addr());
+
+  return v1_packet.bits();
+}
+
+val rvfi_get_v2_trace_size : unit -> bits(32) effect {rreg}
+
+function rvfi_get_v2_trace_size () = {
+  let trace_size = 448;
+  let trace_size = if (rvfi_int_data_present) then trace_size + 256 else trace_size;
+  let trace_size = if (rvfi_mem_data_present) then trace_size + 256 else trace_size;
+  return to_bits(32, trace_size);
+}
+
+val rvfi_get_exec_packet_v2 : unit -> bits(448 + 256 + 256) effect {rreg}
+
+function rvfi_get_exec_packet_v2 () = {
+  // TODO: add the other data
+  // TODO: find a way to return a variable-legnth bitvector
+  let packet = Mk_RVFI_DII_Execution_PacketV2(EXTZ(0b0));
+  let packet = update_trace_version(packet, EXTZ(0x2));
+  let packet = update_basic_data(packet, rvfi_inst_data.bits());
+  let packet = update_pc_data(packet, rvfi_pc_data.bits());
+  let packet = update_integer_data_available(packet, bool_to_bits(rvfi_int_data_present));
+  let packet = update_memory_access_data_available(packet, bool_to_bits(rvfi_mem_data_present));
+  // To simplify the implementation (so that we can return a fixed-size vector)
+  // we always return a max-size packet from this function, and the C emulator
+  // ensures that only trace_size bits are sent over the socket.
+  let packet = update_trace_size(packet, rvfi_get_v2_trace_size());
+  return packet.bits() @ rvfi_int_data.bits() @ rvfi_mem_data.bits();
+}
+
+val rvfi_encode_width_mask : forall 'n, 0 < 'n <= 32. atom('n) -> bits(32)
 
 function rvfi_encode_width_mask(width) =
-  (0xFF >> (8 - width))
+  (0xFFFFFFFF >> (32 - width))
 
 val print_rvfi_exec : unit -> unit effect {rreg}
 
 function print_rvfi_exec () = {
-  print_bits("rvfi_intr     : ", rvfi_exec.rvfi_intr());
-  print_bits("rvfi_halt     : ", rvfi_exec.rvfi_halt());
-  print_bits("rvfi_trap     : ", rvfi_exec.rvfi_trap());
-  print_bits("rvfi_rd_addr  : ", rvfi_exec.rvfi_rd_addr());
-  print_bits("rvfi_rs2_addr : ", rvfi_exec.rvfi_rs2_addr());
-  print_bits("rvfi_rs1_addr : ", rvfi_exec.rvfi_rs1_addr());
-  print_bits("rvfi_mem_wmask: ", rvfi_exec.rvfi_mem_wmask());
-  print_bits("rvfi_mem_rmask: ", rvfi_exec.rvfi_mem_rmask());
-  print_bits("rvfi_mem_wdata: ", rvfi_exec.rvfi_mem_wdata());
-  print_bits("rvfi_mem_rdata: ", rvfi_exec.rvfi_mem_rdata());
-  print_bits("rvfi_mem_addr : ", rvfi_exec.rvfi_mem_addr());
-  print_bits("rvfi_rd_wdata : ", rvfi_exec.rvfi_rd_wdata());
-  print_bits("rvfi_rs2_data : ", rvfi_exec.rvfi_rs2_data());
-  print_bits("rvfi_rs1_data : ", rvfi_exec.rvfi_rs1_data());
-  print_bits("rvfi_insn     : ", rvfi_exec.rvfi_insn());
-  print_bits("rvfi_pc_wdata : ", rvfi_exec.rvfi_pc_wdata());
-  print_bits("rvfi_pc_rdata : ", rvfi_exec.rvfi_pc_rdata());
-  print_bits("rvfi_order    : ", rvfi_exec.rvfi_order());
+  print_bits("rvfi_intr     : ", rvfi_inst_data.rvfi_intr());
+  print_bits("rvfi_halt     : ", rvfi_inst_data.rvfi_halt());
+  print_bits("rvfi_trap     : ", rvfi_inst_data.rvfi_trap());
+  print_bits("rvfi_rd_addr  : ", rvfi_int_data.rvfi_rd_addr());
+  print_bits("rvfi_rs2_addr : ", rvfi_int_data.rvfi_rs2_addr());
+  print_bits("rvfi_rs1_addr : ", rvfi_int_data.rvfi_rs1_addr());
+  print_bits("rvfi_mem_wmask: ", rvfi_mem_data.rvfi_mem_wmask());
+  print_bits("rvfi_mem_rmask: ", rvfi_mem_data.rvfi_mem_rmask());
+  print_bits("rvfi_mem_wdata: ", rvfi_mem_data.rvfi_mem_wdata());
+  print_bits("rvfi_mem_rdata: ", rvfi_mem_data.rvfi_mem_rdata());
+  print_bits("rvfi_mem_addr : ", rvfi_mem_data.rvfi_mem_addr());
+  print_bits("rvfi_rd_wdata : ", rvfi_int_data.rvfi_rd_wdata());
+  print_bits("rvfi_rs2_data : ", rvfi_int_data.rvfi_rs2_rdata());
+  print_bits("rvfi_rs1_data : ", rvfi_int_data.rvfi_rs1_rdata());
+  print_bits("rvfi_insn     : ", rvfi_inst_data.rvfi_insn());
+  print_bits("rvfi_pc_wdata : ", rvfi_pc_data.rvfi_pc_wdata());
+  print_bits("rvfi_pc_rdata : ", rvfi_pc_data.rvfi_pc_rdata());
+  print_bits("rvfi_order    : ", rvfi_inst_data.rvfi_order());
 }


### PR DESCRIPTION
Format should be fairly extensible and providing all the RVFI fields.
See https://github.com/CTSRD-CHERI/QuickCheckVEngine/pull/7 for
the QCVengine changes.

CC: @PeterRugg  @gameboo 