### PR TITLE
Bug fix: when writing CSR sip, ignore attempt to change undelegated SSIP

### DIFF
--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -589,7 +589,7 @@ function lower_mie(m : Minterrupts, d : Minterrupts) -> Sinterrupts = {
 /* Returns the new value of mip from the previous mip (o) and the written sip (s) as delegated by mideleg (d). */
 function lift_sip(o : Minterrupts, d : Minterrupts, s : Sinterrupts) -> Minterrupts = {
   let m : Minterrupts = o;
-  let m = update_SSI(m, s.SSI() & d.SSI());
+  let m = if d.SSI() == 0b1 then update_SSI(m, s.SSI()) else m;
   if haveNExt() then {
     let m = if d.UEI() == 0b1 then update_UEI(m, s.UEI()) else m;
     let m = if d.USI() == 0b1 then update_USI(m, s.USI()) else m;


### PR DESCRIPTION
The `sip` register is special in that is a restricted view of `mip`. Only the bits delegated to S-mode by `mideleg` are visible in `sip`.

Writing to `sip` when `ssip` is not delegated should not change `mip.ssip`.

The Sail model was mistakenly writing 0 to `mip.ssip`, instead of leaving the previous value untouched.
