### PR TITLE
Prevent CSRW to sstatus from modifying uie & upie if N-ext not present

### DIFF
--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -535,7 +535,7 @@ function lift_sstatus(m : Mstatus, s : Sstatus) -> Mstatus = {
 }
 
 function legalize_sstatus(m : Mstatus, v : xlenbits) -> Mstatus = {
-  lift_sstatus(m, Mk_Sstatus(v))
+  legalize_mstatus(m, lift_sstatus(m, Mk_Sstatus(v)).bits())
 }
 
 bitfield Sedeleg : xlenbits = {


### PR DESCRIPTION
A CSRW to the `sstatus` shadow register was erroneously allowed to write to the `uie` and `upie` bits of `mstatus`, even when those bits are supposed to be hardwired to 0 when the N-extension (user-mode interrupts) is not present.

By calling `legalize_mstatus()` I avoid duplicating this logic in `legalize_sstatus()`.