### PR TITLE
MRET and SRET should increment minstret

### DIFF
--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -717,11 +717,10 @@ mapping clause encdec = MRET()
 
 function clause execute MRET() = {
   if   cur_privilege != Machine
-  then handle_illegal()
+  then { handle_illegal(); RETIRE_FAIL }
   else if ~(ext_check_xret_priv (Machine))
-  then ext_fail_xret_priv ()
-  else set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC));
-  RETIRE_FAIL
+  then { ext_fail_xret_priv(); RETIRE_FAIL }
+  else { set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC)); RETIRE_SUCCESS }
 }
 
 mapping clause assembly = MRET() <-> "mret"
@@ -739,11 +738,10 @@ function clause execute SRET() = {
     Machine    => ~ (haveSupMode ())
   };
   if   sret_illegal
-  then handle_illegal()
+  then { handle_illegal(); RETIRE_FAIL }
   else if ~(ext_check_xret_priv (Supervisor))
-  then ext_fail_xret_priv ()
-  else set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC));
-  RETIRE_FAIL
+  then { ext_fail_xret_priv(); RETIRE_FAIL }
+  else { set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC)); RETIRE_SUCCESS }
 }
 
 mapping clause assembly = SRET() <-> "sret"

--- a/model/riscv_insts_base.sail
+++ b/model/riscv_insts_base.sail
@@ -720,7 +720,10 @@ function clause execute MRET() = {
   then { handle_illegal(); RETIRE_FAIL }
   else if ~(ext_check_xret_priv (Machine))
   then { ext_fail_xret_priv(); RETIRE_FAIL }
-  else { set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC)); RETIRE_SUCCESS }
+  else {
+    set_next_pc(exception_handler(cur_privilege, CTL_MRET(), PC));
+    RETIRE_SUCCESS
+  }
 }
 
 mapping clause assembly = MRET() <-> "mret"
@@ -741,7 +744,10 @@ function clause execute SRET() = {
   then { handle_illegal(); RETIRE_FAIL }
   else if ~(ext_check_xret_priv (Supervisor))
   then { ext_fail_xret_priv(); RETIRE_FAIL }
-  else { set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC)); RETIRE_SUCCESS }
+  else {
+    set_next_pc(exception_handler(cur_privilege, CTL_SRET(), PC));
+    RETIRE_SUCCESS
+  }
 }
 
 mapping clause assembly = SRET() <-> "sret"


### PR DESCRIPTION
The ISA spec says that EBREAK and ECALL do not count as committed instructions (and therefore shouldn't increment `minstret`), but it doesn't say anything like that about MRET or SRET. Spike increments `minstret` for those two instructions.

For some reason the Sail model had MRET and SRET returning RETIRE_FAIL instead of RETIRE_SUCCESS. If I am reading the code correctly, this return code is only used to affect the increment of `minstret`, and therefore this change should have no other effects.
