### PR TITLE
Add option to specify SAILCOV output file

### DIFF
--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -95,6 +95,9 @@ void set_config_print(char *var, bool val) {
 struct timeval init_start, init_end, run_end;
 int total_insns = 0;
 int insn_limit = 0;
+#ifdef SAILCOV
+char *sailcov_file = NULL;
+#endif
 
 static struct option options[] = {
   {"enable-dirty-update",         no_argument,       0, 'd'},
@@ -118,6 +121,9 @@ static struct option options[] = {
   {"trace",                       optional_argument, 0, 'v'},
   {"no-trace",                    optional_argument, 0, 'V'},
   {"inst-limit",                  required_argument, 0, 'l'},
+#ifdef SAILCOV
+  {"sailcov-file",                required_argument, 0, 'c'},
+#endif
   {0, 0, 0, 0}
 };
 
@@ -222,6 +228,7 @@ char *process_args(int argc, char **argv)
                     "V::"
                     "v::"
                     "l:"
+                    "c:"
                          , options, NULL);
     if (c == -1) break;
     switch (c) {
@@ -308,6 +315,11 @@ char *process_args(int argc, char **argv)
     case 'l':
       insn_limit = atoi(optarg);
       break;
+#ifdef SAILCOV
+    case 'c':
+      sailcov_file = strdup(optarg);
+      break;
+#endif
     case '?':
       print_usage(argv[0], 1);
       break;
@@ -841,6 +853,12 @@ void init_logs()
     fprintf(stderr, "Cannot create terminal log '%s': %s\n", term_log, strerror(errno));
     exit(1);
   }
+
+#ifdef SAILCOV
+  if (sailcov_file != NULL) {
+    sail_set_coverage_file(sailcov_file);
+  }
+#endif
 }
 
 int main(int argc, char **argv)

--- a/c_emulator/riscv_sim.c
+++ b/c_emulator/riscv_sim.c
@@ -224,11 +224,15 @@ char *process_args(int argc, char **argv)
                     "t:"
                     "T:"
                     "h"
+#ifdef RVFI_DII
                     "r:"
+#endif
                     "V::"
                     "v::"
                     "l:"
+#ifdef SAILCOV
                     "c:"
+#endif
                          , options, NULL);
     if (c == -1) break;
     switch (c) {


### PR DESCRIPTION
This allows a user to change the file that the sail coverage library writes its taken branches to, exposing functionality added to the sail compiler back in August (https://github.com/rems-project/sail/commit/14e5c79b1c6943c88ab36ccc46f073674a76e16c). This allows people to run concurrent copies of the model without the sail_coverage files overwriting one another.