### PR TITLE
PMP address match misses some corner cases

### DIFF
--- a/model/riscv_pmp_control.sail
+++ b/model/riscv_pmp_control.sail
@@ -57,7 +57,7 @@ function pmpMatchAddr(addr: xlenbits, width: xlenbits, rng: pmp_addr_range) -> p
     Some((lo, hi)) => if   hi <_u lo   /* to handle mis-configuration */
                       then PMP_NoMatch
                       else {
-                        if      (addr + width <_u lo) | (hi <_u addr)
+                        if      (addr + width <=_u lo) | (hi <=_u addr)
                         then    PMP_NoMatch
                         else if (lo <=_u addr) & (addr + width <=_u hi)
                         then    PMP_Match


### PR DESCRIPTION
The PMP address match logic misses some corner cases.
Since an entry's legal address is [lo, hi), if one tries to access hi, the address matching result of this entry should be PMP_NoMatch rather than PMP_PartialMatch.
Another corner case is that one tries to access lo, assume width > 0, then address + width = lo should be PMP_NoMatch rather than PMP_PartialMatch (that address should locate in the previous entry).