### PR TITLE
Ignore build library files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 _build/
 _sbuild/
 *.o
+*.a


### PR DESCRIPTION
This prevents git from trying to version the build files in c_emulator/SoftFloat-3e.