### PR TITLE
remove priv check on uret

### DIFF
--- a/model/riscv_insts_next.sail
+++ b/model/riscv_insts_next.sail
@@ -9,8 +9,6 @@ mapping clause encdec = URET()
 function clause execute URET() = {
   if   (~ (haveUsrMode()) | ~(sys_enable_next()))
   then handle_illegal()
-  else if ~ (ext_check_xret_priv (User))
-  then ext_fail_xret_priv ()
   else set_next_pc(exception_handler(cur_privilege, CTL_URET(), PC));
   RETIRE_FAIL
 }


### PR DESCRIPTION
I see this in the priv spec:
An xRET instruction can be executed in privilege mode x or higher
so URET can be executed in all priv modes.  so if I'm reading the SAIL code correctly, I think the priv check can be removed.