### PR TITLE
Allow extensions to set memory privilege level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ endif
 # Non-instruction sources
 PRELUDE = prelude.sail prelude_mapping.sail $(SAIL_XLEN) $(SAIL_FLEN) prelude_mem_metadata.sail prelude_mem.sail
 
-SAIL_REGS_SRCS = riscv_reg_type.sail riscv_freg_type.sail riscv_regs.sail riscv_pc_access.sail riscv_sys_regs.sail
+SAIL_REGS_SRCS = riscv_reg_type.sail riscv_freg_type.sail riscv_regs.sail riscv_pc_access.sail riscv_sys_regs.sail riscv_sys_mem_priv.sail
 SAIL_REGS_SRCS += riscv_pmp_regs.sail riscv_pmp_control.sail
 SAIL_REGS_SRCS += riscv_ext_regs.sail $(SAIL_CHECK_SRCS)
 

--- a/model/riscv_mem.sail
+++ b/model/riscv_mem.sail
@@ -64,7 +64,7 @@ function pmp_mem_read forall 'n, 0 < 'n <= max_mem_access . (t : AccessType(ext_
   if   (~ (plat_enable_pmp ()))
   then checked_mem_read(t, paddr, width, aq, rl, res, meta)
   else {
-    match pmpCheck(paddr, width, t, effectivePrivilege(t, mstatus, cur_privilege)) {
+    match pmpCheck(paddr, width, t, ext_effectiveMemoryPrivilege(t, mstatus, cur_privilege)) {
       None()  => checked_mem_read(t, paddr, width, aq, rl, res, meta),
       Some(e) => MemException(e)
     }
@@ -172,7 +172,7 @@ function pmp_mem_write forall 'n, 0 < 'n <= max_mem_access . (wk: write_kind, pa
   then checked_mem_write(wk, paddr, width, data, meta)
   else {
     let typ : AccessType(ext_access_type) = Write(ext_acc);
-    match pmpCheck(paddr, width, typ, effectivePrivilege(typ, mstatus, cur_privilege)) {
+    match pmpCheck(paddr, width, typ, ext_effectiveMemoryPrivilege(typ, mstatus, cur_privilege)) {
       None()  => checked_mem_write(wk, paddr, width, data, meta),
       Some(e) => MemException(e)
     }

--- a/model/riscv_sys_mem_priv.sail
+++ b/model/riscv_sys_mem_priv.sail
@@ -1,0 +1,14 @@
+/*
+ * Compute the effective memory access privilege as a pure function of...
+ *
+ *  - The memory access type being made, including any extension's annotation
+ *
+ *  - The value of Mstatus
+ *
+ *  - The current privilege level
+ *
+ */
+function ext_effectiveMemoryPrivilege(t : AccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
+  if   t != Execute() & m.MPRV() == 0b1
+  then privLevel_of_bits(m.MPP())
+  else priv

--- a/model/riscv_sys_regs.sail
+++ b/model/riscv_sys_regs.sail
@@ -155,11 +155,6 @@ bitfield Mstatus : xlenbits = {
 }
 register mstatus : Mstatus
 
-function effectivePrivilege(t : AccessType(ext_access_type), m : Mstatus, priv : Privilege) -> Privilege =
-  if   t != Execute() & m.MPRV() == 0b1
-  then privLevel_of_bits(mstatus.MPP())
-  else cur_privilege
-
 function get_mstatus_SXL(m : Mstatus) -> arch_xlen = {
   if   sizeof(xlen) == 32
   then arch_to_bits(RV32)

--- a/model/riscv_vmem_rv32.sail
+++ b/model/riscv_vmem_rv32.sail
@@ -28,7 +28,7 @@ function translationMode(priv) = {
 
 val translateAddr : (xlenbits, AccessType(ext_access_type)) -> TR_Result(xlenbits, ExceptionType) effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
 function translateAddr(vAddr, ac) = {
-  let effPriv : Privilege = effectivePrivilege(ac, mstatus, cur_privilege);
+  let effPriv : Privilege = ext_effectiveMemoryPrivilege(ac, mstatus, cur_privilege);
   let mxr    : bool   = mstatus.MXR() == 0b1;
   let do_sum : bool   = mstatus.SUM() == 0b1;
   let mode : SATPMode = translationMode(effPriv);

--- a/model/riscv_vmem_rv64.sail
+++ b/model/riscv_vmem_rv64.sail
@@ -49,7 +49,7 @@ function translationMode(priv) = {
 
 val translateAddr : (xlenbits, AccessType(ext_access_type)) -> TR_Result(xlenbits, ExceptionType) effect {escape, rmem, rmemt, rreg, wmv, wmvt, wreg}
 function translateAddr(vAddr, ac) = {
-  let effPriv : Privilege = effectivePrivilege(ac, mstatus, cur_privilege);
+  let effPriv : Privilege = ext_effectiveMemoryPrivilege(ac, mstatus, cur_privilege);
   let mxr    : bool   = mstatus.MXR() == 0b1;
   let do_sum : bool   = mstatus.SUM() == 0b1;
   let mode : SATPMode = translationMode(effPriv);


### PR DESCRIPTION
- Move `effectivePrivilege` out to a file that extensions can shadow

- Rename it to `effectiveMemoryPrivilege` for increased clarity

- Make it pure by using its arguments consistently; all information was already
  being passed in as arguments, but, probably as a result of incomplete
  refactorings of yore, global registers were still being used as well.

- Update the call sites and Makefile