### PR TITLE
adding riscof-plugin for sail-riscv c-emulator

### DIFF
--- a/riscof-plugin/sail_cSim/README.md
+++ b/riscof-plugin/sail_cSim/README.md
@@ -1,0 +1,79 @@
+# Riscof Plugin for RISC-V SAIL C-Emulator
+
+This directory provides all the files and artifacts required for running SAIL RISC-V as a Reference model on the 
+[RISCOF](https://github.com/riscv/riscof) framework.
+
+## Getting SAIL RISC-V
+
+The model repository should be cloned from [here](https://github.com/rems-project/sail-riscv).
+
+## Building SAIL RISC-V C-Emulator
+
+The [README.md](../../README.md) at the top level of the sail-riscv repository gives details on 
+building C based executable of the model. You can build both the RV32 and RV64 variants.
+Once built, please add `$SAIL_RISCV/c_emulator` and `$SAIL_RISCV/ocaml_emulator` to your $PATH, 
+where $SAIL_RISCV is the path to the cloned repository.
+
+## Using SAIL RISC-V as a reference model in RISCOF
+
+You will need to edit the `config.ini` file required by RISCOF with the following 
+
+
+```
+# Name of the Plugin. All entries are case sensitive. Including the name.
+[sail_cSim]
+
+#path to the directory where the plugin is present. (required)
+pluginpath=/clone-path/sail-riscv/riscof-plugin/sail_cSim
+
+#path where the `riscv_sim_RV*` binaries are available. (optional)
+#if this value is absent, it is assumed that the binaries are available in the $PATH by default
+PATH=<path-to-binaries>
+
+#number of jobs to spawn in parallel while running tests on sail_cSim (optional)
+jobs=1
+
+#the make command to use while executing the make file. Any of bmake,cmake,pmake,make etc. (optional)
+#Default is make
+make=make
+```
+
+- Export command
+```
+pwd=pwd;export PYTHONPATH=$pwd:$PYTHONPATH;
+```
+
+## About the Plugin
+
+The sail_cSim plugin (`riscof_sail_cSim.py` file) present here has the following four functions:
+
+- \_\_init\_\_: This is the base initialization function. This function will check if the config.ini
+  section corresponding to `sail_cSim` for the following variables and set variables accordingly:
+
+  - PATH: if set in the config.ini file, then the plugin will use this as the sail_cSim executable, else
+    will assume it's available by default in the $PATH
+  - make: if set in config.ini then the plugin uses that command to execute the make file, else
+    default to using the `make` command
+  - jobs: if set in config.ini then the makefile is run with so many jobs in parallel, else defaults
+    to 1
+
+- initialize: This function basically sets up the compiler command for compiling tests. Currently
+  the plugin defaults to using `riscv[64/32]-unknown-elf-gcc` compiler. If you are using an
+  alternate toolchain or executable, you will need to edit this function.
+
+- build: This function will simply deduce the values of the a few compile arguments and check if the
+  required tooling available in the system.
+
+- runTests: This function will first create a Makefile, where each target of the Makefile
+  corresponds to compiling a specific test and then running it on the sail C-emulator. If this plugin is being
+  used to collect coverage of a test via isac, then this function will also append the isac commands
+  for each test in the corresponding Makefile target.
+
+  Note, that the march values for the compiler for each test can be different and are deduced from
+  the test-list provided to this function.
+
+  Once the Makefile is created, this function will execute the makefile targets in parallel
+  depending on the `jobs` value selected in the \_\_init\_\_ function.
+
+This plugin also supports coverage collection using ISAC. 
+

--- a/riscof-plugin/sail_cSim/__init__.py
+++ b/riscof-plugin/sail_cSim/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/riscof-plugin/sail_cSim/env/link.ld
+++ b/riscof-plugin/sail_cSim/env/link.ld
@@ -1,0 +1,18 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(rvtest_entry_point)
+
+SECTIONS
+{
+  . = 0x80000000;
+  .text.init : { *(.text.init) }
+  . = ALIGN(0x1000);
+  .tohost : { *(.tohost) }
+  . = ALIGN(0x1000);
+  .text : { *(.text) }
+  . = ALIGN(0x1000);
+  .data : { *(.data) }
+  .data.string : { *(.data.string)}
+  .bss : { *(.bss) }
+  _end = .;
+}
+

--- a/riscof-plugin/sail_cSim/env/model_test.h
+++ b/riscof-plugin/sail_cSim/env/model_test.h
@@ -1,0 +1,60 @@
+#ifndef _COMPLIANCE_MODEL_H
+#define _COMPLIANCE_MODEL_H
+#if XLEN == 64
+  #define ALIGNMENT 3
+#else
+  #define ALIGNMENT 2
+#endif
+
+#define RVMODEL_DATA_SECTION \
+        .pushsection .tohost,"aw",@progbits;                            \
+        .align 8; .global tohost; tohost: .dword 0;                     \
+        .align 8; .global fromhost; fromhost: .dword 0;                 \
+        .popsection;                                                    \
+        .align 8; .global begin_regstate; begin_regstate:               \
+        .word 128;                                                      \
+        .align 8; .global end_regstate; end_regstate:                   \
+        .word 4;
+
+//RV_COMPLIANCE_HALT
+#define RVMODEL_HALT                                              \
+  li x1, 1;                                                                   \
+  write_tohost:                                                               \
+    sw x1, tohost, t5;                                                        \
+    j write_tohost;
+
+#define RVMODEL_BOOT
+
+//RV_COMPLIANCE_DATA_BEGIN
+#define RVMODEL_DATA_BEGIN                                              \
+  RVMODEL_DATA_SECTION                                                        \
+  .align ALIGNMENT;\
+  .global begin_signature; begin_signature:
+
+//RV_COMPLIANCE_DATA_END
+#define RVMODEL_DATA_END                                                      \
+  .global end_signature; end_signature:  
+
+//RVTEST_IO_INIT
+#define RVMODEL_IO_INIT
+//RVTEST_IO_WRITE_STR
+#define RVMODEL_IO_WRITE_STR(_R, _STR)
+//RVTEST_IO_CHECK
+#define RVMODEL_IO_CHECK()
+//RVTEST_IO_ASSERT_GPR_EQ
+#define RVMODEL_IO_ASSERT_GPR_EQ(_S, _R, _I)
+//RVTEST_IO_ASSERT_SFPR_EQ
+#define RVMODEL_IO_ASSERT_SFPR_EQ(_F, _R, _I)
+//RVTEST_IO_ASSERT_DFPR_EQ
+#define RVMODEL_IO_ASSERT_DFPR_EQ(_D, _R, _I)
+
+#define RVMODEL_SET_MSW_INT
+
+#define RVMODEL_CLEAR_MSW_INT
+
+#define RVMODEL_CLEAR_MTIMER_INT
+
+#define RVMODEL_CLEAR_MEXT_INT
+
+
+#endif // _COMPLIANCE_MODEL_H

--- a/riscof-plugin/sail_cSim/riscof_sail_cSim.py
+++ b/riscof-plugin/sail_cSim/riscof_sail_cSim.py
@@ -1,0 +1,122 @@
+import os
+import re
+import shutil
+import subprocess
+import shlex
+import logging
+import random
+import string
+from string import Template
+
+import riscof.utils as utils
+from riscof.pluginTemplate import pluginTemplate
+import riscof.constants as constants
+from riscv_isac.isac import isac
+
+logger = logging.getLogger()
+
+class sail_cSim(pluginTemplate):
+    __model__ = "sail_c_simulator"
+    __version__ = "0.5.0"
+
+    def __init__(self, *args, **kwargs):
+        sclass = super().__init__(*args, **kwargs)
+
+        config = kwargs.get('config')
+        if config is None:
+            logger.error("Config node for sail_cSim missing.")
+            raise SystemExit
+        self.num_jobs = str(config['jobs'] if 'jobs' in config else 1)
+        self.pluginpath = os.path.abspath(config['pluginpath'])
+        self.sail_exe = { '32' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_RV32"),
+                '64' : os.path.join(config['PATH'] if 'PATH' in config else "","riscv_sim_RV64")}
+        self.isa_spec = os.path.abspath(config['ispec']) if 'ispec' in config else ''
+        self.platform_spec = os.path.abspath(config['pspec']) if 'ispec' in config else ''
+        self.make = config['make'] if 'make' in config else 'make'
+        logger.debug("SAIL CSim plugin initialised using the following configuration.")
+        for entry in config:
+            logger.debug(entry+' : '+config[entry])
+        return sclass
+
+    def initialise(self, suite, work_dir, archtest_env):
+        self.suite = suite
+        self.work_dir = work_dir
+        self.objdump_cmd = 'riscv{1}-unknown-elf-objdump -D {0} > {2};'
+        self.compile_cmd = 'riscv{1}-unknown-elf-gcc -march={0} \
+         -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles\
+         -T '+self.pluginpath+'/env/link.ld\
+         -I '+self.pluginpath+'/env/\
+         -I ' + archtest_env
+
+    def build(self, isa_yaml, platform_yaml):
+        ispec = utils.load_yaml(isa_yaml)['hart0']
+        self.xlen = ('64' if 64 in ispec['supported_xlen'] else '32')
+        self.isa = 'rv' + self.xlen
+        self.compile_cmd = self.compile_cmd+' -mabi='+('lp64 ' if 64 in ispec['supported_xlen'] else 'ilp32 ')
+        if "I" in ispec["ISA"]:
+            self.isa += 'i'
+        if "M" in ispec["ISA"]:
+            self.isa += 'm'
+        if "C" in ispec["ISA"]:
+            self.isa += 'c'
+        if "F" in ispec["ISA"]:
+            self.isa += 'f'
+        if "D" in ispec["ISA"]:
+            self.isa += 'd'
+        objdump = "riscv{0}-unknown-elf-objdump".format(self.xlen)
+        if shutil.which(objdump) is None:
+            logger.error(objdump+": executable not found. Please check environment setup.")
+            raise SystemExit
+        compiler = "riscv{0}-unknown-elf-gcc".format(self.xlen)
+        if shutil.which(compiler) is None:
+            logger.error(compiler+": executable not found. Please check environment setup.")
+            raise SystemExit
+        if shutil.which(self.sail_exe[self.xlen]) is None:
+            logger.error(self.sail_exe[self.xlen]+ ": executable not found. Please check environment setup.")
+            raise SystemExit
+        if shutil.which(self.make) is None:
+            logger.error(self.make+": executable not found. Please check environment setup.")
+            raise SystemExit
+
+
+    def runTests(self, testList,cgf_file=None):
+        make = utils.makeUtil(makefilePath=os.path.join(self.work_dir, "Makefile." + self.name[:-1]))
+        make.makeCommand = self.make + ' -j' + self.num_jobs
+        for file in testList:
+            testentry = testList[file]
+            test = testentry['test_path']
+            test_dir = testentry['work_dir']
+            test_name = test.rsplit('/',1)[1][:-2]
+
+            elf = 'ref.elf'
+
+            execute = "@cd "+testentry['work_dir']+";"
+
+            cmd = self.compile_cmd.format(testentry['isa'].lower(), self.xlen) + ' ' + test + ' -o ' + elf
+            compile_cmd = cmd + ' -D' + " -D".join(testentry['macros'])
+            execute+=compile_cmd+";"
+
+            execute += self.objdump_cmd.format(elf, self.xlen, 'ref.disass')
+            sig_file = os.path.join(test_dir, self.name[:-1] + ".signature")
+
+            execute += self.sail_exe[self.xlen] + ' --test-signature={0} {1} > {2}.log 2>&1;'.format(sig_file, elf, test_name)
+
+            cov_str = ' '
+            for label in testentry['coverage_labels']:
+                cov_str+=' -l '+label
+
+            if cgf_file is not None:
+                coverage_cmd = 'riscv_isac --verbose info coverage -d \
+                        -t {0}.log --parser-name c_sail -o coverage.rpt  \
+                        --sig-label begin_signature  end_signature \
+                        --test-label rvtest_code_begin rvtest_code_end \
+                        -e ref.elf -c {1} -x{2} {3};'.format(\
+                        test_name, ' -c '.join(cgf_file), self.xlen, cov_str)
+            else:
+                coverage_cmd = ''
+
+
+            execute+=coverage_cmd
+
+            make.add_target(execute)
+        make.execute_all(self.work_dir)

--- a/riscof-plugin/sail_cSim/sail_isa.yaml
+++ b/riscof-plugin/sail_cSim/sail_isa.yaml
@@ -1,0 +1,38 @@
+hart_ids: [0]
+hart0:
+  ISA: RV32IMACZicsr_Zifencei
+  physical_addr_sz: 32
+  supported_xlen: [32]
+  misa:
+    reset-val: 0x0
+    rv32:
+      mxl:
+        implemented: false
+      extensions:
+        implemented: false
+      accessible: true
+    rv64:
+      accessible: false
+  mtvec:
+    reset-val: 0x80000000
+    rv32:
+      base:
+        implemented: true
+        type:
+          warl:
+            dependency_fields: []
+            legal:
+            - base[29:0] in [0x20000000]
+            wr_illegal:
+            - Unchanged
+      mode:
+        implemented: true
+        type:
+          warl:
+            dependency_fields: []
+            legal:
+            - mode[1:0] in [0x0]
+            wr_illegal:
+            - Unchanged
+  
+      accessible: true

--- a/riscof-plugin/sail_cSim/sail_platform.yaml
+++ b/riscof-plugin/sail_cSim/sail_platform.yaml
@@ -1,0 +1,4 @@
+nmi:
+  label: nmi_vector
+reset:
+  label: reset_vector


### PR DESCRIPTION
This PR adds the plugin files required to run the SAIL RISC-V C-emulator as a reference model on the new Architectural Testing framework - RISCOF.